### PR TITLE
Fix test signup data generation for groups

### DIFF
--- a/server/src/features/player-assignment/test/utils/verifyUserSignups.ts
+++ b/server/src/features/player-assignment/test/utils/verifyUserSignups.ts
@@ -43,6 +43,7 @@ export const verifyUserSignups = async (): Promise<void> => {
 };
 
 const getGroupLeader = (users: User[], user: User): User => {
+  // User is group member, not group leader
   if (user.groupCode !== '0' && user.groupCode !== user.serial) {
     const groupLeader = users.find(
       (leader) => leader.serial === user.groupCode
@@ -55,5 +56,6 @@ const getGroupLeader = (users: User[], user: User): User => {
     }
   }
 
+  // User is group leader
   return user;
 };

--- a/server/src/test/setupTests.ts
+++ b/server/src/test/setupTests.ts
@@ -6,8 +6,6 @@ logger.info = jest.fn();
 logger.debug = jest.fn();
 
 // Throw if errors are logged
-/*
 logger.error = jest.fn().mockImplementation((message) => {
   throw new Error(message);
 });
-*/

--- a/server/src/test/test-data-generation/generators/createSignups.ts
+++ b/server/src/test/test-data-generation/generators/createSignups.ts
@@ -33,10 +33,13 @@ export const createSignups = async (): Promise<void> => {
   const groupedUsers = _.groupBy(users, 'groupCode');
 
   for (const [groupCode, groupMembers] of Object.entries(groupedUsers)) {
+    // Individual users
     if (groupCode === '0') {
       logger.info('SIGNUP INDIVIDUAL USERS');
       await signupMultiple(games, groupMembers);
-    } else {
+    }
+    // Users in groups
+    else {
       logger.info(`SIGNUP GROUP ${groupCode}`);
       await signupGroup(games, groupMembers);
     }

--- a/server/src/test/test-data-generation/generators/createSignups.ts
+++ b/server/src/test/test-data-generation/generators/createSignups.ts
@@ -32,14 +32,13 @@ export const createSignups = async (): Promise<void> => {
 
   const groupedUsers = _.groupBy(users, 'groupCode');
 
-  for (const [key, value] of Object.entries(groupedUsers)) {
-    const array = [...value];
-    if (key === '0') {
+  for (const [groupCode, groupMembers] of Object.entries(groupedUsers)) {
+    if (groupCode === '0') {
       logger.info('SIGNUP INDIVIDUAL USERS');
-      await signupMultiple(games, array);
+      await signupMultiple(games, groupMembers);
     } else {
-      logger.info(`SIGNUP GROUP ${key}`);
-      await signupGroup(games, array);
+      logger.info(`SIGNUP GROUP ${groupCode}`);
+      await signupGroup(games, groupMembers);
     }
   }
 
@@ -118,21 +117,14 @@ const signupGroup = async (
   games: readonly Game[],
   users: readonly User[]
 ): Promise<void> => {
-  // Generate random signup data for the first user
-  const firstUser = _.first(users);
-  if (!firstUser) throw new Error('Error getting first user of group');
-  const signedGames = getRandomSignup(games);
+  // Generate random signup data for the group leader
+  const leader = users.find((user) => user.serial === user.groupCode);
+  if (!leader) throw new Error('Error getting group leader');
 
-  // Assign same signup data for group members
-  const promises: Array<Promise<User>> = [];
-  for (let i = 0; i < users.length; i++) {
-    const signupData = {
-      username: users[i].username,
-      signedGames: i === 0 ? signedGames : [],
-    };
+  const signupData = {
+    username: leader.username,
+    signedGames: getRandomSignup(games),
+  };
 
-    promises.push(saveSignup(signupData));
-  }
-
-  await Promise.all(promises);
+  await saveSignup(signupData);
 };


### PR DESCRIPTION
* Fix test signup data generation for groups
  * Group members don't have signup data, only group leader
  * Don't assume first group member is the leader
* Refactor function `getCurrentEnteredGames()`