### PR TITLE
Simplify auth header check

### DIFF
--- a/client/src/views/signup/components/DropRow.tsx
+++ b/client/src/views/signup/components/DropRow.tsx
@@ -51,13 +51,14 @@ export const DropRow: FC<Props> = (props: Props): ReactElement => {
                 draggableId={game.gameId}
                 index={index}
               >
-                {(provided2) => (
+                {/* eslint-disable-next-line @typescript-eslint/no-shadow */}
+                {(provided) => (
                   <Link to={`/games/${game.gameId}`}>
                     <DraggableItem
                       className={`${getPopularity(game)}`}
                       ref={provided.innerRef}
-                      {...provided2.draggableProps}
-                      {...provided2.dragHandleProps}
+                      {...provided.draggableProps}
+                      {...provided.dragHandleProps}
                     >
                       <SignupGameTitle className='break-long'>
                         {game.title}

--- a/server/src/features/feedback/feedbackController.ts
+++ b/server/src/features/feedback/feedbackController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { validateAuthHeader } from 'server/utils/authHeader';
+import { isAuthorized } from 'server/utils/authHeader';
 import { UserGroup } from 'shared/typings/models/user';
 import { storeFeedback } from 'server/features/feedback/feedbackService';
 import { logger } from 'server/utils/logger';
@@ -12,17 +12,11 @@ export const postFeedback = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${FEEDBACK_ENDPOINT}`);
 
-  const feedbackData = req.body.feedbackData;
-
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
+  const feedbackData = req.body.feedbackData;
   const response = await storeFeedback(feedbackData);
-  return res.send(response);
+  return res.json(response);
 };

--- a/server/src/features/game/gameController.ts
+++ b/server/src/features/game/gameController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { validateAuthHeader } from 'server/utils/authHeader';
+import { isAuthorized } from 'server/utils/authHeader';
 import { UserGroup } from 'shared/typings/models/user';
 import { fetchGames, storeGames } from 'server/features/game/gamesService';
 import { logger } from 'server/utils/logger';
@@ -11,17 +11,12 @@ export const postGame = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${GAMES_ENDPOINT}`);
 
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.ADMIN
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN)) {
     return res.sendStatus(401);
   }
 
   const response = await storeGames();
-  return res.send(response);
+  return res.json(response);
 };
 
 export const getGames = async (
@@ -31,5 +26,5 @@ export const getGames = async (
   logger.info(`API call: GET ${GAMES_ENDPOINT}`);
 
   const response = await fetchGames();
-  return res.send(response);
+  return res.json(response);
 };

--- a/server/src/features/results/resultsController.ts
+++ b/server/src/features/results/resultsController.ts
@@ -3,7 +3,7 @@ import { Record, String } from 'runtypes';
 import { storeAssignment } from 'server/features/player-assignment/assignmentController';
 import { fetchResults } from 'server/features/results/resultsService';
 import { UserGroup } from 'shared/typings/models/user';
-import { validateAuthHeader } from 'server/utils/authHeader';
+import { isAuthorized } from 'server/utils/authHeader';
 import { logger } from 'server/utils/logger';
 import {
   ASSIGNMENT_ENDPOINT,
@@ -34,7 +34,7 @@ export const getResults = async (
   }
 
   const response = await fetchResults(startTime);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const postAssignment = async (
@@ -43,17 +43,11 @@ export const postAssignment = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ASSIGNMENT_ENDPOINT}`);
 
-  const startingTime = req.body.startingTime;
-
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.ADMIN
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN)) {
     return res.sendStatus(401);
   }
 
+  const startingTime = req.body.startingTime;
   const response = await storeAssignment(startingTime);
-  return res.send(response);
+  return res.json(response);
 };

--- a/server/src/features/settings/settingsController.ts
+++ b/server/src/features/settings/settingsController.ts
@@ -6,7 +6,7 @@ import {
   storeHidden,
 } from 'server/features/settings/settingsService';
 import { UserGroup } from 'shared/typings/models/user';
-import { validateAuthHeader } from 'server/utils/authHeader';
+import { isAuthorized } from 'server/utils/authHeader';
 import { logger } from 'server/utils/logger';
 import {
   HIDDEN_ENDPOINT,
@@ -22,19 +22,13 @@ export const postHidden = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${HIDDEN_ENDPOINT}`);
 
-  const hiddenData = req.body.hiddenData;
-
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.ADMIN
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN)) {
     return res.sendStatus(401);
   }
 
+  const hiddenData = req.body.hiddenData;
   const response = await storeHidden(hiddenData);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const postSignupTime = async (
@@ -43,19 +37,13 @@ export const postSignupTime = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${SIGNUPTIME_ENDPOINT}`);
 
-  const signupTime = req.body.signupTime;
-
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.ADMIN
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN)) {
     return res.sendStatus(401);
   }
 
+  const signupTime = req.body.signupTime;
   const response = await storeSignupTime(signupTime);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const postAppOpen = async (
@@ -64,19 +52,13 @@ export const postAppOpen = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${TOGGLE_APP_OPEN_ENDPOINT}`);
 
-  const appOpen = req.body.appOpen;
-
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.ADMIN
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN)) {
     return res.sendStatus(401);
   }
 
+  const appOpen = req.body.appOpen;
   const response = await toggleAppOpen(appOpen);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const getSettings = async (
@@ -86,5 +68,5 @@ export const getSettings = async (
   logger.info(`API call: GET ${SETTINGS_ENDPOINT}`);
 
   const response = await fetchSettings();
-  return res.send(response);
+  return res.json(response);
 };

--- a/server/src/features/user/userController.ts
+++ b/server/src/features/user/userController.ts
@@ -14,7 +14,7 @@ import {
   removeEnteredGame,
 } from 'server/features/user/userService';
 import { UserGroup } from 'shared/typings/models/user';
-import { validateAuthHeader } from 'server/utils/authHeader';
+import { isAuthorized } from 'server/utils/authHeader';
 import { logger } from 'server/utils/logger';
 import {
   ENTERED_GAME_ENDPOINT,
@@ -48,7 +48,7 @@ export const postUser = async (
   const { username, password, serial, changePassword } = req.body;
 
   const response = await storeUser(username, password, serial, changePassword);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const postLogin = async (
@@ -65,7 +65,7 @@ export const postLogin = async (
 
   // @ts-expect-error: TODO
   const response = await login(username, password, jwt);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const postFavorite = async (
@@ -74,19 +74,13 @@ export const postFavorite = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${FAVORITE_ENDPOINT}`);
 
-  const favoriteData = req.body.favoriteData;
-
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
+  const favoriteData = req.body.favoriteData;
   const response = await storeFavorite(favoriteData);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const postGroup = async (
@@ -95,12 +89,7 @@ export const postGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${GROUP_ENDPOINT}`);
 
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
@@ -116,7 +105,7 @@ export const postGroup = async (
     leaveGroup,
     closeGroup
   );
-  return res.send(response);
+  return res.json(response);
 };
 
 export const getUser = async (
@@ -125,12 +114,7 @@ export const getUser = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${USERS_ENDPOINT}`);
 
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
@@ -153,7 +137,7 @@ export const getUser = async (
   }
 
   const response = await fetchUserByUsername(username);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const getUserBySerial = async (
@@ -162,12 +146,7 @@ export const getUserBySerial = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${USERS_BY_SERIAL_ENDPOINT}`);
 
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
@@ -192,7 +171,7 @@ export const getUserBySerial = async (
   }
 
   const response = await fetchUserBySerial(serial);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const getGroup = async (
@@ -201,12 +180,7 @@ export const getGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${GROUP_ENDPOINT}`);
 
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
@@ -225,7 +199,7 @@ export const getGroup = async (
   const { groupCode } = queryParameters;
 
   const response = await fetchGroup(groupCode);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const postSignup = async (
@@ -234,21 +208,15 @@ export const postSignup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${SIGNUP_ENDPOINT}`);
 
-  const signupData = req.body.signupData;
-
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
+  const signupData = req.body.signupData;
   const { selectedGames, username, signupTime } = signupData;
 
   const response = await storeSignup(selectedGames, username, signupTime);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const postEnteredGame = async (
@@ -257,12 +225,7 @@ export const postEnteredGame = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ENTERED_GAME_ENDPOINT}`);
 
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
@@ -282,7 +245,7 @@ export const postEnteredGame = async (
   }
 
   const response = await storeEnteredGame(req.body.enteredGameRequest);
-  return res.send(response);
+  return res.json(response);
 };
 
 export const deleteEnteredGame = async (
@@ -291,12 +254,7 @@ export const deleteEnteredGame = async (
 ): Promise<Response> => {
   logger.info(`API call: DELETE ${ENTERED_GAME_ENDPOINT}`);
 
-  const validToken = validateAuthHeader(
-    req.headers.authorization,
-    UserGroup.USER
-  );
-
-  if (!validToken) {
+  if (!isAuthorized(req.headers.authorization, UserGroup.USER)) {
     return res.sendStatus(401);
   }
 
@@ -316,5 +274,5 @@ export const deleteEnteredGame = async (
   }
 
   const response = await removeEnteredGame(req.body.enteredGameRequest);
-  return res.send(response);
+  return res.json(response);
 };

--- a/server/src/utils/authHeader.ts
+++ b/server/src/utils/authHeader.ts
@@ -2,28 +2,27 @@ import { verifyJWT } from 'server/utils/jwt';
 import { logger } from 'server/utils/logger';
 import { UserGroup } from 'shared/typings/models/user';
 
-export const validateAuthHeader = (
+export const isAuthorized = (
   authHeader: string | undefined,
-  userGroup: UserGroup
+  requiredUserGroup: UserGroup
 ): boolean => {
-  logger.debug(`Auth: Require jwt for user group "${userGroup}"`);
-  let jwt = '';
+  logger.debug(`Auth: Require jwt for user group "${requiredUserGroup}"`);
 
-  if (authHeader) {
-    // Strip 'bearer' from authHeader
-    jwt = authHeader.split('Bearer ')[1];
-  } else {
+  if (!authHeader || authHeader.split(' ')[0] !== 'Bearer') {
     logger.info(`Auth: No auth header`);
     return false;
   }
 
-  const jwtResponse = verifyJWT(jwt, userGroup);
+  // Strip 'bearer' from authHeader
+  const jwt = authHeader.split('Bearer ')[1];
 
-  if (jwtResponse.status !== 'error') {
-    logger.debug(`Auth: Valid jwt for user group "${userGroup}" `);
-    return true;
-  } else {
-    logger.info(`Auth: Invalid jwt for user group "${userGroup}"`);
+  const jwtResponse = verifyJWT(jwt, requiredUserGroup);
+
+  if (jwtResponse.status === 'error') {
+    logger.info(`Auth: Invalid jwt for user group "${requiredUserGroup}"`);
     return false;
   }
+
+  logger.debug(`Auth: Valid jwt for user group "${requiredUserGroup}" `);
+  return true;
 };

--- a/server/src/utils/jwt.ts
+++ b/server/src/utils/jwt.ts
@@ -3,27 +3,17 @@ import { config } from 'server/config';
 import { JWTResult } from 'server/typings/jwt.typings';
 import { UserGroup } from 'shared/typings/models/user';
 
-const getSecret = (userGroup: UserGroup): string => {
-  if (userGroup === 'admin') {
-    return config.jwtSecretKeyAdmin;
-  } else if (userGroup === 'user') {
-    return config.jwtSecretKey;
-  } else if (userGroup === 'help') {
-    return config.jwtSecretKey;
-  }
-  return '';
-};
-
 export const getJWT = (userGroup: UserGroup, username: string): string => {
+  const payload = {
+    username,
+    userGroup,
+  };
+
   const options = {
     expiresIn: '2 days',
   };
 
-  return jsonwebtoken.sign(
-    { username, userGroup },
-    getSecret(userGroup),
-    options
-  );
+  return jsonwebtoken.sign(payload, getSecret(userGroup), options);
 };
 
 export const verifyJWT = (jwt: string, userGroup: UserGroup): JWTResult => {
@@ -63,4 +53,15 @@ export const verifyJWT = (jwt: string, userGroup: UserGroup): JWTResult => {
 
 export const decodeJWT = (jwt: string): JWTResult => {
   return jsonwebtoken.decode(jwt) as JWTResult;
+};
+
+const getSecret = (userGroup: UserGroup): string => {
+  if (userGroup === 'admin') {
+    return config.jwtSecretKeyAdmin;
+  } else if (userGroup === 'user') {
+    return config.jwtSecretKey;
+  } else if (userGroup === 'help') {
+    return config.jwtSecretKey;
+  }
+  return '';
 };


### PR DESCRIPTION
* Simplify auth header check
* Call `res.json` instead of `res.send` since we always respond with json
* Fix regression: rename `provided2` to `provided`