### PR TITLE
Rename state variable admin.signupTime

### DIFF
--- a/client/src/typings/redux.typings.ts
+++ b/client/src/typings/redux.typings.ts
@@ -8,7 +8,7 @@ import { SelectedGame, UserGroup } from 'shared/typings/models/user';
 
 export interface AdminState {
   hiddenGames: readonly Game[];
-  signupTime: string;
+  activeSignupTime: string;
   testTime: string;
   appOpen: boolean;
   responseMessage: string;

--- a/client/src/utils/loadData.ts
+++ b/client/src/utils/loadData.ts
@@ -51,10 +51,10 @@ export const loadResults = async (): Promise<void> => {
   const state = store.getState();
   const dispatch: AppDispatch = store.dispatch;
   const { loggedIn } = state.login;
-  const { signupTime } = state.admin;
+  const { activeSignupTime } = state.admin;
 
-  if (loggedIn && signupTime) {
-    await dispatch(submitGetResults(signupTime));
+  if (loggedIn && activeSignupTime) {
+    await dispatch(submitGetResults(activeSignupTime));
   }
 };
 

--- a/client/src/views/admin/AdminView.tsx
+++ b/client/src/views/admin/AdminView.tsx
@@ -15,7 +15,9 @@ import { useAppDispatch, useAppSelector } from 'client/utils/hooks';
 
 export const AdminView = (): ReactElement => {
   const games = useAppSelector((state) => state.allGames.games);
-  const signupTime = useAppSelector((state) => state.admin.signupTime);
+  const activeSignupTime = useAppSelector(
+    (state) => state.admin.activeSignupTime
+  );
   const appOpen = useAppSelector((state) => state.admin.appOpen);
   const hiddenGames = useAppSelector((state) => state.admin.hiddenGames);
   const responseMessage = useAppSelector(
@@ -29,7 +31,7 @@ export const AdminView = (): ReactElement => {
   const [message, setMessage] = useState<string>('');
   const [messageStyle, setMessageStyle] = useState<string>('');
   const [selectedSignupTime, setSelectedSignupTime] =
-    useState<string>(signupTime);
+    useState<string>(activeSignupTime);
 
   const showMessage = ({
     value,
@@ -81,7 +83,7 @@ export const AdminView = (): ReactElement => {
     setSubmitting(true);
 
     try {
-      await dispatch(submitPlayersAssign(signupTime));
+      await dispatch(submitPlayersAssign(activeSignupTime));
     } catch (error) {
       showMessage({
         value: error.message,
@@ -156,16 +158,16 @@ export const AdminView = (): ReactElement => {
           <p>{t('activeTimeDescription')}</p>
 
           <div className={'signup-open'}>
-            {signupTime && (
+            {activeSignupTime && (
               <p>
                 {t('activeTime')}:{' '}
                 {timeFormatter.getWeekdayAndTime({
-                  time: signupTime,
+                  time: activeSignupTime,
                   capitalize: true,
                 })}
               </p>
             )}
-            {!signupTime && <p>{t('noActiveTime')}</p>}
+            {!activeSignupTime && <p>{t('noActiveTime')}</p>}
           </div>
 
           <button

--- a/client/src/views/admin/adminSlice.ts
+++ b/client/src/views/admin/adminSlice.ts
@@ -5,7 +5,7 @@ import { Game } from 'shared/typings/models/game';
 
 const initialState: AdminState = {
   hiddenGames: [],
-  signupTime: '',
+  activeSignupTime: '',
   testTime: '',
   appOpen: true,
   responseMessage: '',
@@ -26,13 +26,13 @@ const adminSlice = createSlice({
       return {
         ...state,
         hiddenGames: action.payload.hiddenGames,
-        signupTime: action.payload.signupTime,
+        activeSignupTime: action.payload.signupTime,
         appOpen: action.payload.appOpen,
       };
     },
 
-    submitSignupTimeAsync(state, action: PayloadAction<string>) {
-      return { ...state, signupTime: action.payload };
+    submitActiveSignupTimeAsync(state, action: PayloadAction<string>) {
+      return { ...state, activeSignupTime: action.payload };
     },
 
     submitSetTestTime(state, action: PayloadAction<string>) {
@@ -52,7 +52,7 @@ const adminSlice = createSlice({
 export const {
   submitUpdateHiddenAsync,
   submitGetSettingsAsync,
-  submitSignupTimeAsync,
+  submitActiveSignupTimeAsync,
   submitSetTestTime,
   submitToggleAppOpenAsync,
   submitResponseMessageAsync,

--- a/client/src/views/admin/adminThunks.ts
+++ b/client/src/views/admin/adminThunks.ts
@@ -9,7 +9,7 @@ import { AppThunk } from 'client/typings/redux.typings';
 import {
   submitUpdateHiddenAsync,
   submitGetSettingsAsync,
-  submitSignupTimeAsync,
+  submitActiveSignupTimeAsync,
   submitToggleAppOpenAsync,
 } from 'client/views/admin/adminSlice';
 
@@ -56,7 +56,7 @@ export const submitSignupTime = (signupTime: string): AppThunk => {
     }
 
     if (signupTimeResponse?.status === 'success') {
-      dispatch(submitSignupTimeAsync(signupTimeResponse.signupTime));
+      dispatch(submitActiveSignupTimeAsync(signupTimeResponse.signupTime));
     }
   };
 };

--- a/client/src/views/results/ResultsView.tsx
+++ b/client/src/views/results/ResultsView.tsx
@@ -8,7 +8,9 @@ import { useAppSelector } from 'client/utils/hooks';
 
 export const ResultsView = (): ReactElement => {
   const results = useAppSelector((state) => state.results.result);
-  const signupTime = useAppSelector((state) => state.admin.signupTime);
+  const activeSignupTime = useAppSelector(
+    (state) => state.admin.activeSignupTime
+  );
   const { t } = useTranslation();
 
   const store = useStore();
@@ -27,13 +29,13 @@ export const ResultsView = (): ReactElement => {
 
   return (
     <div className='results-view'>
-      {!signupTime && <h2>{t('noResults')}</h2>}
-      {signupTime && (
+      {!activeSignupTime && <h2>{t('noResults')}</h2>}
+      {activeSignupTime && (
         <>
           <h2>
             {t('signupResultsfor')}{' '}
             {timeFormatter.getWeekdayAndTime({
-              time: signupTime,
+              time: activeSignupTime,
               capitalize: false,
             })}
           </h2>

--- a/shared/constants/apiEndpoints.ts
+++ b/shared/constants/apiEndpoints.ts
@@ -10,6 +10,6 @@ export const SIGNUPTIME_ENDPOINT = '/api/signuptime';
 export const FEEDBACK_ENDPOINT = '/api/feedback';
 export const GROUP_ENDPOINT = '/api/group';
 export const TOGGLE_APP_OPEN_ENDPOINT = '/api/toggle-app-open';
-export const SETTINGS_ENDPOINT = '/api/settigs';
+export const SETTINGS_ENDPOINT = '/api/settings';
 export const RESULTS_ENDPOINT = '/api/results';
 export const ENTERED_GAME_ENDPOINT = '/api/enteredgame';


### PR DESCRIPTION
We have `state.admin.signupTime` and `state.signup.signupTime`. Rename state `admin.signupTime` to avoid confusion.
