### PR TITLE
Allow saving signup messages

### DIFF
--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -29,7 +29,9 @@
     "cancel": "Cancel",
     "helper": "Helper",
     "find": "Find",
-    "save": "Save"
+    "save": "Save",
+    "addSignupMessage": "Add textfield",
+    "removeSignupMessage": "Delete textfield"
   },
   "username": "Username",
   "password": "Password",
@@ -240,5 +242,8 @@
     "noSignups": "No signed up players",
     "players": "Players",
     "noStartingGames": "No starting games"
+  },
+  "gameDetails": {
+    "addSignupTextField": "Add signup additional info field"
   }
 }

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -29,7 +29,9 @@
     "cancel": "Peruuta",
     "helper": "Apuja",
     "find": "Etsi",
-    "save": "Tallenna"
+    "save": "Tallenna",
+    "addSignupMessage": "Lisää tekstikenttä",
+    "removeSignupMessage": "Poista tekstikenttä"
   },
   "username": "Käyttäjänimi",
   "password": "Salasana",
@@ -241,5 +243,8 @@
     "noSignups": "Ei ilmoittautuneita pelaajia",
     "players": "Pelaajia",
     "noStartingGames": "Ei alkavia pelejä"
+  },
+  "gameDetails": {
+    "addSignupTextField": "Lisää ilmoittautumisen lisätietokenttä"
   }
 }

--- a/client/src/services/settingsServices.ts
+++ b/client/src/services/settingsServices.ts
@@ -2,13 +2,16 @@ import { AxiosResponse, AxiosError } from 'axios';
 import { api } from 'client/utils/api';
 import {
   SETTINGS_ENDPOINT,
+  SIGNUP_MESSAGE_ENDPOINT,
   TOGGLE_APP_OPEN_ENDPOINT,
 } from 'shared/constants/apiEndpoints';
 import { ServerError } from 'shared/typings/api/errors';
 import {
   GetSettingsResponse,
+  PostSignupMessageResponse,
   PostToggleAppOpenResponse,
 } from 'shared/typings/api/settings';
+import { SignupMessage } from 'shared/typings/models/settings';
 
 export const getSettings = async (): Promise<
   GetSettingsResponse | ServerError
@@ -36,6 +39,50 @@ export const postToggleAppOpen = async (
       TOGGLE_APP_OPEN_ENDPOINT,
       {
         appOpen,
+      }
+    );
+  } catch (error) {
+    if (error?.response) {
+      const axiosError: AxiosError<ServerError> = error;
+      if (axiosError.response) return axiosError.response.data;
+    }
+    throw error;
+  }
+
+  return response.data;
+};
+
+export const postSignupMessage = async (
+  signupMessage: SignupMessage
+): Promise<PostSignupMessageResponse | ServerError> => {
+  let response: AxiosResponse;
+  try {
+    response = await api.post<PostSignupMessageResponse>(
+      SIGNUP_MESSAGE_ENDPOINT,
+      {
+        signupMessage,
+      }
+    );
+  } catch (error) {
+    if (error?.response) {
+      const axiosError: AxiosError<ServerError> = error;
+      if (axiosError.response) return axiosError.response.data;
+    }
+    throw error;
+  }
+
+  return response.data;
+};
+
+export const deleteSignupMessage = async (
+  gameId: string
+): Promise<PostSignupMessageResponse | ServerError> => {
+  let response: AxiosResponse;
+  try {
+    response = await api.delete<PostSignupMessageResponse>(
+      SIGNUP_MESSAGE_ENDPOINT,
+      {
+        data: { gameId },
       }
     );
   } catch (error) {

--- a/client/src/typings/redux.typings.ts
+++ b/client/src/typings/redux.typings.ts
@@ -5,6 +5,7 @@ import { GroupMember } from 'shared/typings/api/groups';
 import { Result } from 'shared/typings/models/result';
 import { store, combinedReducer } from 'client/utils/store';
 import { SelectedGame, UserGroup } from 'shared/typings/models/user';
+import { SignupMessage } from 'shared/typings/models/settings';
 
 export interface AdminState {
   hiddenGames: readonly Game[];
@@ -12,6 +13,7 @@ export interface AdminState {
   testTime: string;
   appOpen: boolean;
   responseMessage: string;
+  signupMessages: readonly SignupMessage[];
 }
 
 export interface UsersForGame {

--- a/client/src/views/admin/adminSlice.ts
+++ b/client/src/views/admin/adminSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { AdminState } from 'client/typings/redux.typings';
 import { SubmitGetSettingsPayload } from 'client/views/admin/adminTypes';
 import { Game } from 'shared/typings/models/game';
+import { SignupMessage } from 'shared/typings/models/settings';
 
 const initialState: AdminState = {
   hiddenGames: [],
@@ -9,6 +10,7 @@ const initialState: AdminState = {
   testTime: '',
   appOpen: true,
   responseMessage: '',
+  signupMessages: [],
 };
 
 const adminSlice = createSlice({
@@ -28,6 +30,7 @@ const adminSlice = createSlice({
         hiddenGames: action.payload.hiddenGames,
         activeSignupTime: action.payload.signupTime,
         appOpen: action.payload.appOpen,
+        signupMessages: action.payload.signupMessages,
       };
     },
 
@@ -46,6 +49,13 @@ const adminSlice = createSlice({
     submitResponseMessageAsync(state, action: PayloadAction<string>) {
       return { ...state, responseMessage: action.payload };
     },
+
+    updateSignupMessages(
+      state,
+      action: PayloadAction<readonly SignupMessage[]>
+    ) {
+      return { ...state, signupMessages: action.payload };
+    },
   },
 });
 
@@ -56,6 +66,7 @@ export const {
   submitSetTestTime,
   submitToggleAppOpenAsync,
   submitResponseMessageAsync,
+  updateSignupMessages,
 } = adminSlice.actions;
 
 export const adminReducer = adminSlice.reducer;

--- a/client/src/views/admin/adminThunks.ts
+++ b/client/src/views/admin/adminThunks.ts
@@ -1,6 +1,8 @@
 import { postHidden } from 'client/services/hiddenServices';
 import {
+  deleteSignupMessage,
   getSettings,
+  postSignupMessage,
   postToggleAppOpen,
 } from 'client/services/settingsServices';
 import { postSignupTime } from 'client/services/signuptimeServices';
@@ -11,7 +13,9 @@ import {
   submitGetSettingsAsync,
   submitActiveSignupTimeAsync,
   submitToggleAppOpenAsync,
+  updateSignupMessages,
 } from 'client/views/admin/adminSlice';
+import { SignupMessage } from 'shared/typings/models/settings';
 
 export const submitUpdateHidden = (hiddenGames: readonly Game[]): AppThunk => {
   return async (dispatch): Promise<void> => {
@@ -41,6 +45,7 @@ export const submitGetSettings = (): AppThunk => {
           hiddenGames: settingsResponse.hiddenGames,
           signupTime: settingsResponse.signupTime,
           appOpen: settingsResponse.appOpen,
+          signupMessages: settingsResponse.signupMessages,
         })
       );
     }
@@ -71,6 +76,39 @@ export const submitToggleAppOpen = (appOpen: boolean): AppThunk => {
 
     if (appOpenResponse?.status === 'success') {
       dispatch(submitToggleAppOpenAsync(appOpenResponse.appOpen));
+    }
+  };
+};
+
+export const submitAddSignupMessage = (
+  signupMessage: SignupMessage
+): AppThunk => {
+  return async (dispatch): Promise<void> => {
+    const response = await postSignupMessage({
+      gameId: signupMessage.gameId,
+      message: signupMessage.message,
+    });
+
+    if (response?.status === 'error') {
+      return await Promise.reject(response);
+    }
+
+    if (response?.status === 'success') {
+      dispatch(updateSignupMessages(response.signupMessages));
+    }
+  };
+};
+
+export const submitDeleteSignupMessage = (gameId: string): AppThunk => {
+  return async (dispatch): Promise<void> => {
+    const response = await deleteSignupMessage(gameId);
+
+    if (response?.status === 'error') {
+      return await Promise.reject(response);
+    }
+
+    if (response?.status === 'success') {
+      dispatch(updateSignupMessages(response.signupMessages));
     }
   };
 };

--- a/client/src/views/admin/adminTypes.ts
+++ b/client/src/views/admin/adminTypes.ts
@@ -1,7 +1,9 @@
 import { Game } from 'shared/typings/models/game';
+import { SignupMessage } from 'shared/typings/models/settings';
 
 export interface SubmitGetSettingsPayload {
   hiddenGames: readonly Game[];
   signupTime: string;
   appOpen: boolean;
+  signupMessages: readonly SignupMessage[];
 }

--- a/client/src/views/all-games/components/GameDetails.tsx
+++ b/client/src/views/all-games/components/GameDetails.tsx
@@ -1,7 +1,11 @@
-import React, { ReactElement, useState, useEffect } from 'react';
+import React, { ReactElement, useState, useEffect, ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
-import { submitUpdateHidden } from 'client/views/admin/adminThunks';
+import {
+  submitAddSignupMessage,
+  submitDeleteSignupMessage,
+  submitUpdateHidden,
+} from 'client/views/admin/adminThunks';
 import { FeedbackForm } from 'client/views/all-games/components/FeedbackForm';
 import { GameInfo } from 'client/views/all-games/components/GameInfo';
 import { Loading } from 'client/components/Loading';
@@ -9,6 +13,7 @@ import { Game } from 'shared/typings/models/game';
 import { updateFavorite, UpdateFavoriteOpts } from 'client/utils/favorite';
 import { useAppDispatch, useAppSelector } from 'client/utils/hooks';
 import { Button } from 'client/components/Button';
+import styled from 'styled-components';
 
 export const GameDetails = (): ReactElement => {
   const history = useHistory();
@@ -23,6 +28,7 @@ export const GameDetails = (): ReactElement => {
     (state) => state.myGames.favoritedGames
   );
   const hiddenGames = useAppSelector((state) => state.admin.hiddenGames);
+  const signupMessages = useAppSelector((state) => state.admin.signupMessages);
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
@@ -30,8 +36,13 @@ export const GameDetails = (): ReactElement => {
 
   const [hidden, setHidden] = useState<boolean>(false);
   const [favorited, setFavorited] = useState<boolean>(false);
+  const [hasSignupMessage, setHasSignupMessage] = useState<boolean>(false);
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
+
+  const [signupMessageInput, setSignupMessageInput] = useState<string>('');
+  const [signupMessageInputVisible, setSignupMessageInputVisible] =
+    useState<boolean>(false);
 
   useEffect(() => {
     setLoading(true);
@@ -52,11 +63,18 @@ export const GameDetails = (): ReactElement => {
           setHidden(true);
         }
       });
+
+      // Check if signup message exinsts
+      signupMessages.find((signupMessageForGame) => {
+        if (signupMessageForGame.gameId === foundGame.gameId) {
+          setHasSignupMessage(true);
+        }
+      });
     };
 
     checkGameState();
     setLoading(false);
-  }, [foundGame, favoritedGames, hiddenGames]);
+  }, [foundGame, favoritedGames, hiddenGames, signupMessages]);
 
   // Favorite / remove favorite clicked
   const updateFavoriteHandler = async (action: string): Promise<void> => {
@@ -115,6 +133,30 @@ export const GameDetails = (): ReactElement => {
     }
   };
 
+  const handleSignupMessageChange = (
+    event: ChangeEvent<HTMLInputElement>
+  ): void => {
+    setSignupMessageInput(event.target.value);
+  };
+
+  const onSubmitAddSignupMessageClick = (): void => {
+    if (!foundGame) return;
+    dispatch(
+      submitAddSignupMessage({
+        gameId: foundGame.gameId,
+        message: signupMessageInput,
+      })
+    );
+    setSignupMessageInputVisible(false);
+    setSignupMessageInput('');
+  };
+
+  const submitRemoveSignupMessage = (): void => {
+    if (!foundGame) return;
+    dispatch(submitDeleteSignupMessage(foundGame.gameId));
+    setHasSignupMessage(false);
+  };
+
   return (
     <div className='game-details-view'>
       <div className='details-button-row'>
@@ -165,9 +207,60 @@ export const GameDetails = (): ReactElement => {
             {t('button.hide')}
           </Button>
         )}
+
+        {!hasSignupMessage &&
+          !signupMessageInputVisible &&
+          loggedIn &&
+          userGroup === 'admin' &&
+          foundGame && (
+            <Button
+              disabled={submitting}
+              onClick={() => setSignupMessageInputVisible(true)}
+            >
+              {t('button.addSignupMessage')}
+            </Button>
+          )}
+
+        {!hasSignupMessage &&
+          signupMessageInputVisible &&
+          loggedIn &&
+          userGroup === 'admin' &&
+          foundGame && (
+            <Button
+              disabled={submitting}
+              onClick={() => setSignupMessageInputVisible(false)}
+            >
+              {t('button.cancel')}
+            </Button>
+          )}
+
+        {hasSignupMessage && loggedIn && userGroup === 'admin' && foundGame && (
+          <Button
+            disabled={submitting}
+            onClick={() => submitRemoveSignupMessage()}
+          >
+            {t('button.removeSignupMessage')}
+          </Button>
+        )}
       </div>
 
       {loading && <Loading />}
+
+      {signupMessageInputVisible && (
+        <>
+          <p>{t('gameDetails.addSignupTextField')}</p>
+          <FormInput
+            type={'text'}
+            key='new-password'
+            placeholder={t('gameDetails.addSignupTextField')}
+            value={signupMessageInput}
+            onChange={handleSignupMessageChange}
+          />
+          <Button onClick={onSubmitAddSignupMessageClick}>
+            {t('button.save')}
+          </Button>
+        </>
+      )}
 
       {!loading && !foundGame && (
         <div className='game-not-found'>
@@ -194,3 +287,11 @@ const findGame = (gameId: string, array: readonly Game[]): number => {
   }
   return -1;
 };
+
+const FormInput = styled.input`
+  border: 1px solid ${(props) => props.theme.borderInactive};
+  color: ${(props) => props.theme.buttonText};
+  height: 34px;
+  padding: 0 0 0 10px;
+  width: 100%;
+`;

--- a/client/src/views/all-games/components/GameDetails.tsx
+++ b/client/src/views/all-games/components/GameDetails.tsx
@@ -139,7 +139,7 @@ export const GameDetails = (): ReactElement => {
     setSignupMessageInput(event.target.value);
   };
 
-  const onSubmitAddSignupMessageClick = (): void => {
+  const onClickAddSignupMessage = (): void => {
     if (!foundGame) return;
     dispatch(
       submitAddSignupMessage({
@@ -151,7 +151,7 @@ export const GameDetails = (): ReactElement => {
     setSignupMessageInput('');
   };
 
-  const submitRemoveSignupMessage = (): void => {
+  const onClickDeleteSignupMessage = (): void => {
     if (!foundGame) return;
     dispatch(submitDeleteSignupMessage(foundGame.gameId));
     setHasSignupMessage(false);
@@ -235,10 +235,7 @@ export const GameDetails = (): ReactElement => {
           )}
 
         {hasSignupMessage && loggedIn && userGroup === 'admin' && foundGame && (
-          <Button
-            disabled={submitting}
-            onClick={() => submitRemoveSignupMessage()}
-          >
+          <Button disabled={submitting} onClick={onClickDeleteSignupMessage}>
             {t('button.removeSignupMessage')}
           </Button>
         )}
@@ -256,9 +253,7 @@ export const GameDetails = (): ReactElement => {
             value={signupMessageInput}
             onChange={handleSignupMessageChange}
           />
-          <Button onClick={onSubmitAddSignupMessageClick}>
-            {t('button.save')}
-          </Button>
+          <Button onClick={onClickAddSignupMessage}>{t('button.save')}</Button>
         </>
       )}
 

--- a/server/src/api/apiRoutes.ts
+++ b/server/src/api/apiRoutes.ts
@@ -7,9 +7,11 @@ import {
   postAssignment,
 } from 'server/features/results/resultsController';
 import {
+  deleteSignupMessage,
   getSettings,
   postAppOpen,
   postHidden,
+  postSignupMessage,
   postSignupTime,
 } from 'server/features/settings/settingsController';
 import {
@@ -39,6 +41,7 @@ import {
   SETTINGS_ENDPOINT,
   SIGNUPTIME_ENDPOINT,
   SIGNUP_ENDPOINT,
+  SIGNUP_MESSAGE_ENDPOINT,
   TOGGLE_APP_OPEN_ENDPOINT,
   USERS_BY_SERIAL_ENDPOINT,
   USERS_ENDPOINT,
@@ -62,6 +65,7 @@ apiRoutes.post(FEEDBACK_ENDPOINT, postFeedback);
 apiRoutes.post(GROUP_ENDPOINT, postGroup);
 apiRoutes.post(TOGGLE_APP_OPEN_ENDPOINT, postAppOpen);
 apiRoutes.post(ENTERED_GAME_ENDPOINT, postEnteredGame);
+apiRoutes.post(SIGNUP_MESSAGE_ENDPOINT, postSignupMessage);
 
 /* GET routes */
 
@@ -75,5 +79,6 @@ apiRoutes.get(GROUP_ENDPOINT, getGroup);
 /* DELETE routes */
 
 apiRoutes.delete(ENTERED_GAME_ENDPOINT, deleteEnteredGame);
+apiRoutes.delete(SIGNUP_MESSAGE_ENDPOINT, deleteSignupMessage);
 
 /* eslint-enable @typescript-eslint/no-misused-promises */

--- a/server/src/features/settings/settingsController.ts
+++ b/server/src/features/settings/settingsController.ts
@@ -4,6 +4,8 @@ import {
   toggleAppOpen,
   storeSignupTime,
   storeHidden,
+  storeSignupMessage,
+  removeSignupMessage,
 } from 'server/features/settings/settingsService';
 import { UserGroup } from 'shared/typings/models/user';
 import { isAuthorized } from 'server/utils/authHeader';
@@ -12,9 +14,11 @@ import {
   HIDDEN_ENDPOINT,
   SETTINGS_ENDPOINT,
   SIGNUPTIME_ENDPOINT,
+  SIGNUP_MESSAGE_ENDPOINT,
   TOGGLE_APP_OPEN_ENDPOINT,
 } from 'shared/constants/apiEndpoints';
 import { Game } from 'shared/typings/models/game';
+import { SignupMessage } from 'shared/typings/models/settings';
 
 export const postHidden = async (
   req: Request<{}, {}, { hiddenData: readonly Game[] }>,
@@ -68,5 +72,33 @@ export const getSettings = async (
   logger.info(`API call: GET ${SETTINGS_ENDPOINT}`);
 
   const response = await fetchSettings();
+  return res.json(response);
+};
+
+export const postSignupMessage = async (
+  req: Request<{}, {}, { signupMessage: SignupMessage }>,
+  res: Response
+): Promise<Response> => {
+  logger.info(`API call: POST ${SIGNUP_MESSAGE_ENDPOINT}`);
+
+  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN)) {
+    return res.sendStatus(401);
+  }
+
+  const response = await storeSignupMessage(req.body.signupMessage);
+  return res.json(response);
+};
+
+export const deleteSignupMessage = async (
+  req: Request<{}, {}, { gameId: string }>,
+  res: Response
+): Promise<Response> => {
+  logger.info(`API call: DELETE ${SIGNUP_MESSAGE_ENDPOINT}`);
+
+  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN)) {
+    return res.sendStatus(401);
+  }
+
+  const response = await removeSignupMessage(req.body.gameId);
   return res.json(response);
 };

--- a/server/src/features/settings/settingsSchema.ts
+++ b/server/src/features/settings/settingsSchema.ts
@@ -8,6 +8,7 @@ const SettingsSchema = new mongoose.Schema(
     ],
     signupTime: { type: Date, default: null },
     appOpen: { type: Boolean, default: true },
+    signupMessages: [{ gameId: { type: String }, message: { type: String } }],
   },
   { timestamps: true }
 );

--- a/server/src/features/settings/settingsService.ts
+++ b/server/src/features/settings/settingsService.ts
@@ -3,17 +3,21 @@ import {
   saveSignupTime,
   saveToggleAppOpen,
   saveHidden,
+  saveSignupMessage,
+  delSignupMessage,
 } from 'server/features/settings/settingsRepository';
 import { logger } from 'server/utils/logger';
 import { ServerError } from 'shared/typings/api/errors';
 import {
   GetSettingsResponse,
   PostHiddenResponse,
+  PostSignupMessageResponse,
   PostToggleAppOpenResponse,
 } from 'shared/typings/api/settings';
 import { PostSignupTimeResponse } from 'shared/typings/api/signup';
 import { Game } from 'shared/typings/models/game';
 import { removeHiddenGamesFromUsers } from 'server/features/settings/settingsUtils';
+import { SignupMessage } from 'shared/typings/models/settings';
 
 export const fetchSettings = async (): Promise<
   GetSettingsResponse | ServerError
@@ -27,6 +31,7 @@ export const fetchSettings = async (): Promise<
       hiddenGames: response.hiddenGames,
       signupTime: response.signupTime || '',
       appOpen: response.appOpen,
+      signupMessages: response.signupMessages,
     };
   } catch (error) {
     logger.error(`Settings: ${error}`);
@@ -106,5 +111,49 @@ export const storeHidden = async (
     message: 'Update hidden success',
     status: 'success',
     hiddenGames: settings.hiddenGames,
+  };
+};
+
+export const storeSignupMessage = async (
+  signupMessageData: SignupMessage
+): Promise<PostSignupMessageResponse | ServerError> => {
+  let settings;
+  try {
+    settings = await saveSignupMessage(signupMessageData);
+  } catch (error) {
+    logger.error(`saveSignupMessage error: ${error}`);
+    return {
+      message: 'saveSignupMessage failure',
+      status: 'error',
+      code: 0,
+    };
+  }
+
+  return {
+    message: 'saveSignupMessage success',
+    status: 'success',
+    signupMessages: settings.signupMessages,
+  };
+};
+
+export const removeSignupMessage = async (
+  gameId: string
+): Promise<PostSignupMessageResponse | ServerError> => {
+  let settings;
+  try {
+    settings = await delSignupMessage(gameId);
+  } catch (error) {
+    logger.error(`delSignupMessage error: ${error}`);
+    return {
+      message: 'delSignupMessage failure',
+      status: 'error',
+      code: 0,
+    };
+  }
+
+  return {
+    message: 'delSignupMessage success',
+    status: 'success',
+    signupMessages: settings.signupMessages,
   };
 };

--- a/shared/constants/apiEndpoints.ts
+++ b/shared/constants/apiEndpoints.ts
@@ -13,3 +13,4 @@ export const TOGGLE_APP_OPEN_ENDPOINT = '/api/toggle-app-open';
 export const SETTINGS_ENDPOINT = '/api/settings';
 export const RESULTS_ENDPOINT = '/api/results';
 export const ENTERED_GAME_ENDPOINT = '/api/enteredgame';
+export const SIGNUP_MESSAGE_ENDPOINT = '/api/signup-info';

--- a/shared/typings/api/settings.ts
+++ b/shared/typings/api/settings.ts
@@ -1,4 +1,5 @@
 import { Game } from 'shared/typings/models/game';
+import { SignupMessage } from 'shared/typings/models/settings';
 
 export interface PostHiddenResponse {
   hiddenGames: readonly Game[];
@@ -12,10 +13,17 @@ export interface GetSettingsResponse {
   message: string;
   signupTime: string;
   status: 'success';
+  signupMessages: readonly SignupMessage[];
 }
 
 export interface PostToggleAppOpenResponse {
   appOpen: boolean;
+  message: string;
+  status: 'success';
+}
+
+export interface PostSignupMessageResponse {
+  signupMessages: readonly SignupMessage[];
   message: string;
   status: 'success';
 }

--- a/shared/typings/models/settings.ts
+++ b/shared/typings/models/settings.ts
@@ -4,4 +4,10 @@ export interface Settings {
   hiddenGames: readonly Game[];
   signupTime: string;
   appOpen: boolean;
+  signupMessages: SignupMessage[];
+}
+
+export interface SignupMessage {
+  gameId: string;
+  message: string;
 }


### PR DESCRIPTION
Allow saving and deleting signup messages from `GameDetails` view. Messages can be used to provide additional information with signup.

![image](https://user-images.githubusercontent.com/1327412/122684822-7a69dd00-d210-11eb-81ca-cc1ca065c4e5.png)

![image](https://user-images.githubusercontent.com/1327412/122684825-7e95fa80-d210-11eb-8486-a6c31710b62a.png)
