### PR TITLE
Don't show colon after username on overview list

### DIFF
--- a/client/src/views/results/components/DirectResults.tsx
+++ b/client/src/views/results/components/DirectResults.tsx
@@ -105,9 +105,9 @@ export const DirectResults = (): ReactElement => {
                       ) : (
                         users.map((user) => (
                           <p key={user.username}>
-                            {user.username}:{' '}
+                            {user.username}
                             {signupMessagesVisible && (
-                              <span>{user.signupMessage}</span>
+                              <span>: {user.signupMessage}</span>
                             )}
                           </p>
                         ))


### PR DESCRIPTION
Don't show colon after username on overview list. Show it only when signup question answers are toggled.