### PR TITLE
Update Express catch-all route to return 404 for api endpoint not found

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -84,7 +84,11 @@ const devConfig = {
   jwtSecretKey: "secret",
   jwtSecretKeyAdmin: "admin secret",
   jwtSecretKeyHelp: "help secret",
-  allowedCorsOrigins: ["http://localhost:8000", "https://server:5000"],
+  allowedCorsOrigins: [
+    "http://localhost:8000",
+    "http://localhost:5000",
+    "https://server:5000",
+  ],
   useLocalProgramFile: false,
   debug: false,
   GROUP_ASSIGNMENT_ROUNDS: 1,

--- a/server/src/utils/server.ts
+++ b/server/src/utils/server.ts
@@ -66,8 +66,12 @@ export const startServer = async (
     app.use(express.static(staticPath));
   }
 
-  app.get("/", (_req: Request, res: Response) => {
-    res.sendFile(path.join(staticPath, "index.html"));
+  app.get("/*", (req: Request, res: Response) => {
+    if (req.originalUrl.includes("/api/")) {
+      res.sendStatus(404);
+    } else {
+      res.sendFile(path.join(staticPath, "index.html"));
+    }
   });
 
   let server: Server;


### PR DESCRIPTION
Update Express catch-all route to return 404 for api endpoint not found