### PR TITLE
Fix game list title in mobile devices

### DIFF
--- a/client/src/views/all-games/components/GameListTitle.tsx
+++ b/client/src/views/all-games/components/GameListTitle.tsx
@@ -51,7 +51,12 @@ export const GameListTitle = ({
       isVisible={!!isIntersecting}
     >
       <StyledGameListTitle>
-        <StartTime>{formattedStartTime}</StartTime>
+        <StartTimeContainer>
+          <StartTime>{formattedStartTime}</StartTime>
+          {timeslotSignupStrategy === SignupStrategy.ALGORITHM && (
+            <SignupCount>{signedGamesCount} / 3</SignupCount>
+          )}
+        </StartTimeContainer>
 
         {timeslotSignupStrategy === SignupStrategy.ALGORITHM && (
           <span>
@@ -59,12 +64,10 @@ export const GameListTitle = ({
           </span>
         )}
 
-        {timeslotSignupStrategy === SignupStrategy.DIRECT ? (
+        {timeslotSignupStrategy === SignupStrategy.DIRECT && (
           <SignupCount>
             {signedGame ? signedGame.gameDetails.title : ""}
           </SignupCount>
-        ) : (
-          <SignupCount>{signedGamesCount} / 3</SignupCount>
         )}
       </StyledGameListTitle>
 
@@ -81,6 +84,11 @@ export const GameListTitle = ({
     </GameListTitleContainer>
   );
 };
+
+const StartTimeContainer = styled.span`
+  display: flex;
+  justify-content: space-between;
+`;
 
 const SignupCount = styled.span`
   float: right;
@@ -104,6 +112,8 @@ const GameListTitleContainer = styled.div<{ isVisible: boolean }>`
 `;
 
 const StyledGameListTitle = styled.h3`
+  display: flex;
+  flex-direction: column;
   margin: 0;
   padding: 0;
 `;


### PR DESCRIPTION
Start time and participant count are now in one row and
other information has its own row.

- Please do not create a Pull Request without discussing the change first.
- Please provide enough information so others can review your Pull Request.
<img width="509" alt="Screenshot 2022-06-26 at 20 10 43" src="https://user-images.githubusercontent.com/182336/175825932-2a3a45cc-24de-41b4-8329-7ccb2aff2004.png">
<img width="509" alt="Screenshot 2022-06-26 at 20 11 12" src="https://user-images.githubusercontent.com/182336/175825933-361e0b96-11cd-4967-abdd-e622052e30ef.png">
