### PR TITLE
Add endpoint to fetch signup messages and show in UI

### DIFF
--- a/client/src/components/ErrorBar.tsx
+++ b/client/src/components/ErrorBar.tsx
@@ -17,8 +17,6 @@ export const ErrorBar = (): ReactElement | null => {
 
   const errors = useAppSelector((state) => state.admin.errors);
 
-  if (!errors) return null;
-
   const errorList = errors.map((error) => {
     return (
       <StyledError

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -337,6 +337,7 @@
   "private": "Private",
   "privateOnlyVisibleToOrganizers": "Only visible to organizers",
   "helperView": {
+    "signupQuestionAnswers": "Signup question answers",
     "privateSignupMessagesInfo": "Private signup info for contacting tournament participants"
   }
 }

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -337,6 +337,7 @@
   "private": "Yksityinen",
   "privateOnlyVisibleToOrganizers": "Näkyy ainoastaan järjestäjille",
   "helperView": {
+    "signupQuestionAnswers": "Ilmoittautumiskysymysten vastaukset",
     "privateSignupMessagesInfo": "Yksityiset ilmoittautumisen lisätiedot turnausten osallistujien tavoittamiseen."
   }
 }

--- a/client/src/services/userServices.ts
+++ b/client/src/services/userServices.ts
@@ -8,6 +8,10 @@ import {
   PostUserResponse,
 } from "shared/typings/api/users";
 import { RegistrationFormFields } from "shared/typings/api/login";
+import {
+  GetSignupMessagesError,
+  GetSignupMessagesResponse,
+} from "shared/typings/models/signupMessage";
 
 export const postRegistration = async (
   registrationFormFields: RegistrationFormFields
@@ -59,6 +63,15 @@ export const updateUserPassword = async (
       password,
       requester,
     }
+  );
+  return response.data;
+};
+
+export const getSignupMessages = async (): Promise<
+  GetSignupMessagesResponse | GetSignupMessagesError
+> => {
+  const response = await api.get<GetSignupMessagesResponse>(
+    ApiEndpoint.SIGNUP_MESSAGE
   );
   return response.data;
 };

--- a/client/src/typings/redux.typings.ts
+++ b/client/src/typings/redux.typings.ts
@@ -10,6 +10,7 @@ import { UserSignup } from "shared/typings/api/games";
 import { SignupStrategy } from "shared/config/sharedConfig.types";
 import { UserGames } from "shared/typings/api/users";
 import { ErrorMessageType } from "client/components/ErrorBar";
+import { SignupMessage } from "shared/typings/models/signupMessage";
 
 export interface AdminState {
   hiddenGames: readonly Game[];
@@ -20,6 +21,7 @@ export interface AdminState {
   signupStrategy: SignupStrategy | undefined;
   errors: readonly ErrorMessageType[];
   activeProgramType: ProgramType;
+  signupMessages: readonly SignupMessage[];
 }
 
 export interface UsersForGame {

--- a/client/src/utils/store.ts
+++ b/client/src/utils/store.ts
@@ -1,7 +1,6 @@
 import { combineReducers, CombinedState, AnyAction } from "redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { config } from "client/config";
-import { loadSession } from "client/utils/localStorage";
 import { RootState } from "client/typings/redux.typings";
 import { SUBMIT_LOGOUT } from "client/typings/logoutActions.typings";
 
@@ -52,7 +51,6 @@ const rootReducer = (
 
 export const store = configureStore({
   reducer: rootReducer,
-  preloadedState: loadSession(), // Load persisted state from localStorage
   devTools:
     process.env.SETTINGS !== "production"
       ? {

--- a/client/src/views/admin/adminSlice.ts
+++ b/client/src/views/admin/adminSlice.ts
@@ -6,16 +6,24 @@ import { SubmitGetSettingsPayload } from "client/views/admin/adminTypes";
 import { SignupStrategy } from "shared/config/sharedConfig.types";
 import { Game, ProgramType } from "shared/typings/models/game";
 import { SignupQuestion } from "shared/typings/models/settings";
+import { SignupMessage } from "shared/typings/models/signupMessage";
+import { loadSession } from "client/utils/localStorage";
 
-const initialState: AdminState = {
-  hiddenGames: [],
-  activeSignupTime: "",
-  appOpen: true,
-  responseMessage: "",
-  signupQuestions: [],
-  signupStrategy: undefined,
-  errors: [],
-  activeProgramType: ProgramType.TABLETOP_RPG,
+const initialState = (): AdminState => {
+  const persistedState = loadSession();
+
+  return {
+    hiddenGames: [],
+    activeSignupTime: "",
+    appOpen: true,
+    responseMessage: "",
+    signupQuestions: [],
+    signupStrategy: undefined,
+    errors: [],
+    activeProgramType:
+      persistedState?.admin?.activeProgramType ?? ProgramType.TABLETOP_RPG,
+    signupMessages: [],
+  };
 };
 
 const adminSlice = createSlice({
@@ -80,6 +88,13 @@ const adminSlice = createSlice({
     setActiveProgramType(state, action: PayloadAction<ProgramType>) {
       return { ...state, activeProgramType: action.payload };
     },
+
+    submitGetSignupMessagesAsync(
+      state,
+      action: PayloadAction<SignupMessage[]>
+    ) {
+      return { ...state, signupMessages: action.payload };
+    },
   },
 });
 
@@ -94,6 +109,7 @@ export const {
   addError,
   removeError,
   setActiveProgramType,
+  submitGetSignupMessagesAsync,
 } = adminSlice.actions;
 
 export const adminReducer = adminSlice.reducer;

--- a/client/src/views/admin/adminThunks.ts
+++ b/client/src/views/admin/adminThunks.ts
@@ -14,9 +14,11 @@ import {
   submitToggleAppOpenAsync,
   updateSignupQuestions,
   submitSetSignupStrategyAsync,
+  submitGetSignupMessagesAsync,
 } from "client/views/admin/adminSlice";
 import { SignupQuestion } from "shared/typings/models/settings";
 import { SignupStrategy } from "shared/config/sharedConfig.types";
+import { getSignupMessages } from "client/services/userServices";
 
 export const submitUpdateHidden = (hiddenGames: readonly Game[]): AppThunk => {
   return async (dispatch): Promise<void> => {
@@ -130,6 +132,20 @@ export const submitSetSignupStrategy = (
 
     if (response?.status === "success") {
       dispatch(submitSetSignupStrategyAsync(response.settings.signupStrategy));
+    }
+  };
+};
+
+export const submitGetSignupMessages = (): AppThunk => {
+  return async (dispatch): Promise<void> => {
+    const response = await getSignupMessages();
+
+    if (response?.status === "error") {
+      // TODO
+    }
+
+    if (response?.status === "success") {
+      dispatch(submitGetSignupMessagesAsync(response.signupMessages));
     }
   };
 };

--- a/client/src/views/helper/components/PrivateSignupMessages.tsx
+++ b/client/src/views/helper/components/PrivateSignupMessages.tsx
@@ -1,40 +1,63 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useAppSelector } from "client/utils/hooks";
+import _ from "lodash";
+import styled from "styled-components";
+import { useAppDispatch, useAppSelector } from "client/utils/hooks";
+import { submitGetSignupMessages } from "client/views/admin/adminThunks";
 
 export const PrivateSignupMessages = (): ReactElement => {
   const { t } = useTranslation();
+  const dispatch = useAppDispatch();
 
   const games = useAppSelector((state) => state.allGames.games);
   const signupQuestions = useAppSelector(
     (state) => state.admin.signupQuestions
   );
+  const signupMessages = useAppSelector((state) => state.admin.signupMessages);
 
-  const privateSignupQuestions = signupQuestions.filter(
-    (signupQuestion) => signupQuestion.private
+  const privateSignupMessages = signupMessages.filter(
+    (signupMessage) => signupMessage.private
   );
+
+  const groupedSignupMessages = _.groupBy(privateSignupMessages, "gameId");
+
+  useEffect(() => {
+    dispatch(submitGetSignupMessages());
+  }, []);
 
   return (
     <div>
-      <h3>{t("signupQuestions")}</h3>
+      <h3>{t("helperView.signupQuestionAnswers")}</h3>
       <p>{t("helperView.privateSignupMessagesInfo")}</p>
 
-      {privateSignupQuestions.map((signupQuestion) => {
-        const matchingGame = games.find(
-          (game) => game.gameId === signupQuestion.gameId
-        );
+      {Object.entries(groupedSignupMessages).map(([gameId, answers]) => {
+        const matchingGame = games.find((game) => game.gameId === gameId);
         if (!matchingGame) return null;
 
+        const matchingSignupQuestion = signupQuestions.find(
+          (signupQuestion) => signupQuestion.gameId === gameId
+        );
+        if (!matchingSignupQuestion) return null;
+
         return (
-          <p key={signupQuestion.gameId}>
+          <SingleGameAnswers key={gameId}>
             <Link to={`/games/${matchingGame.gameId}`}>
               {matchingGame.title}
             </Link>{" "}
-            {signupQuestion.message}
-          </p>
+            <p>{matchingSignupQuestion?.message}</p>
+            {answers.map((answer) => (
+              <li key={answer.username}>
+                {answer.username}: {answer.message}
+              </li>
+            ))}
+          </SingleGameAnswers>
         );
       })}
     </div>
   );
 };
+
+const SingleGameAnswers = styled.div`
+  margin-bottom: 16px;
+`;

--- a/client/src/views/login/loginSlice.ts
+++ b/client/src/views/login/loginSlice.ts
@@ -2,13 +2,18 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { LoginState } from "client/typings/redux.typings";
 import { UserGroup } from "shared/typings/models/user";
 import { SubmitLoginPayload } from "client/views/login/loginTypes";
+import { loadSession } from "client/utils/localStorage";
 
-const initialState: LoginState = {
-  username: "",
-  loggedIn: false,
-  jwt: "",
-  userGroup: UserGroup.USER,
-  serial: "",
+const initialState = (): LoginState => {
+  const persistedState = loadSession();
+
+  return {
+    username: "",
+    loggedIn: false,
+    jwt: persistedState?.login?.jwt ?? "",
+    userGroup: UserGroup.USER,
+    serial: "",
+  };
 };
 
 const loginSlice = createSlice({

--- a/server/src/api/apiRoutes.ts
+++ b/server/src/api/apiRoutes.ts
@@ -28,6 +28,7 @@ import {
 import { postLogin } from "server/features/user/login/loginController";
 import { postSessionRestore } from "server/features/user/session-restore/sessionRestoreController";
 import { postSignedGames } from "server/features/user/signed-game/signedGameController";
+import { getSignupMessages } from "server/features/user/signup-message/signupMessageController";
 import {
   getUser,
   postUser,
@@ -76,6 +77,7 @@ apiRoutes.get(
 apiRoutes.get(ApiEndpoint.SETTINGS, getSettings);
 apiRoutes.get(ApiEndpoint.RESULTS, getResults);
 apiRoutes.get(ApiEndpoint.GROUP, getGroup);
+apiRoutes.get(ApiEndpoint.SIGNUP_MESSAGE, getSignupMessages);
 
 /* DELETE routes */
 

--- a/server/src/features/user/signup-message/signupMessageController.ts
+++ b/server/src/features/user/signup-message/signupMessageController.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from "express";
+import { logger } from "server/utils/logger";
+import { ApiEndpoint } from "shared/constants/apiEndpoints";
+import { isAuthorized } from "server/utils/authHeader";
+import { UserGroup } from "shared/typings/models/user";
+import { fetchSignupMessages } from "server/features/user/signup-message/signupMessageService";
+
+export const getSignupMessages = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  logger.info(`API call: GET ${ApiEndpoint.SIGNUP_MESSAGE}`);
+
+  if (!isAuthorized(req.headers.authorization, UserGroup.HELP, "helper")) {
+    return res.sendStatus(401);
+  }
+
+  const response = await fetchSignupMessages();
+  return res.json(response);
+};

--- a/server/src/features/user/signup-message/signupMessageService.ts
+++ b/server/src/features/user/signup-message/signupMessageService.ts
@@ -1,0 +1,50 @@
+import { findSettings } from "server/features/settings/settingsRepository";
+import { findUsers } from "server/features/user/userRepository";
+import { Settings } from "shared/typings/models/settings";
+import {
+  GetSignupMessagesError,
+  GetSignupMessagesResponse,
+} from "shared/typings/models/signupMessage";
+import { User } from "shared/typings/models/user";
+
+export const fetchSignupMessages = async (): Promise<
+  GetSignupMessagesResponse | GetSignupMessagesError
+> => {
+  let users: User[];
+  let settings: Settings;
+  try {
+    users = await findUsers();
+    settings = await findSettings();
+  } catch (error) {
+    return {
+      message: "Error loading data from DB",
+      status: "error",
+      errorId: "unknown",
+    };
+  }
+
+  const signupMessages = users.flatMap((user) => {
+    return user.enteredGames.flatMap((enteredGame) => {
+      if (enteredGame.message) {
+        const signupQuestion = settings.signupQuestions.find(
+          (question) => question.gameId === enteredGame.gameDetails.gameId
+        );
+        if (!signupQuestion) return [];
+
+        return {
+          gameId: enteredGame.gameDetails.gameId,
+          username: user.username,
+          message: enteredGame.message,
+          private: signupQuestion?.private,
+        };
+      }
+      return [];
+    });
+  });
+
+  return {
+    signupMessages,
+    message: "Succesfully loaded signup messages",
+    status: "success",
+  };
+};

--- a/shared/constants/apiEndpoints.ts
+++ b/shared/constants/apiEndpoints.ts
@@ -16,6 +16,7 @@ export enum ApiEndpoint {
   RESULTS = "/api/results",
   ENTERED_GAME = "/api/entered-game",
   SIGNUP_QUESTION = "/api/signup-question",
+  SIGNUP_MESSAGE = "/api/signup-message",
   SESSION_RESTORE = "/api/session-restore",
   USERS_PASSWORD = "/api/users/password",
   TEST_SETTINGS = "/api/test-settings",

--- a/shared/typings/models/signupMessage.ts
+++ b/shared/typings/models/signupMessage.ts
@@ -1,0 +1,18 @@
+import { ApiError } from "shared/typings/api/errors";
+
+export interface SignupMessage {
+  gameId: string;
+  username: string;
+  message: string;
+  private: boolean;
+}
+
+export interface GetSignupMessagesResponse {
+  signupMessages: SignupMessage[];
+  message: string;
+  status: "success";
+}
+
+export interface GetSignupMessagesError extends ApiError {
+  errorId: "unknown";
+}


### PR DESCRIPTION
* Add endpoint to fetch signup messages
* Show private messages in helper UI
* Remove `preloadedState` from store initialization. It messed up reducer specific initial states.

![image](https://user-images.githubusercontent.com/1327412/177013483-8e7c0e9f-851e-4063-940c-0f358067170b.png)
