### PR TITLE
Add way to mark games as 'signup always open'

### DIFF
--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -284,7 +284,8 @@
     "playerCount": "Players {{MAX_ATTENDANCE}}",
     "playerRange": "Players {{MIN_ATTENDANCE}} - {{MAX_ATTENDANCE}}",
     "signupOpens": "Signup opens",
-    "preSignupOpens": "Pre-signup opens"
+    "preSignupOpens": "Pre-signup opens",
+    "signupAlwaysOpen": "Signup for special always open"
   },
   "resultsView": {
     "allSignupResults": "Signup overview and players",

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -284,7 +284,8 @@
     "playerCount": "Pelaajia {{MAX_ATTENDANCE}}",
     "playerRange": "Pelaajia {{MIN_ATTENDANCE}} - {{MAX_ATTENDANCE}}",
     "signupOpens": "Ilmoittautuminen aukeaa",
-    "preSignupOpens": "Ennakkoilmoittautuminen aukeaa"
+    "preSignupOpens": "Ennakkoilmoittautuminen aukeaa",
+    "signupAlwaysOpen": "Ilmoittautuminen erikoispeliin aina auki"
   },
   "resultsView": {
     "allSignupResults": "Ilmoittautumistilanne ja pelaajat",

--- a/client/src/views/all-games/components/GameEntry.tsx
+++ b/client/src/views/all-games/components/GameEntry.tsx
@@ -17,6 +17,7 @@ import {
 } from "client/utils/getUpcomingGames";
 import { isAlreadyEntered, isAlreadySigned } from "./allGamesUtils";
 import { PopularityInfo } from "client/components/PopularityInfo";
+import { sharedConfig } from "shared/config/sharedConfig";
 
 const DESCRIPTION_SENTENCES_LENGTH = 3;
 const matchNextSentence = /([.?!])\s*(?=[A-Z])/g;
@@ -57,12 +58,17 @@ export const GameEntry = ({
 
   const dispatch = useAppDispatch();
 
+  const signupAlwaysOpen = sharedConfig.directSignupAlwaysOpen.includes(
+    game.gameId
+  );
+
   const favorited =
     favoritedGames.find(
       (favoritedGame) => favoritedGame.gameId === game.gameId
     ) !== undefined;
 
-  const isEnterGameMode = signupStrategy === SignupStrategy.DIRECT;
+  const isEnterGameMode =
+    signupStrategy === SignupStrategy.DIRECT || signupAlwaysOpen;
   const gameIsFull = game.maxAttendance === players;
 
   const formatDuration = (mins: number): string => {
@@ -100,6 +106,11 @@ export const GameEntry = ({
       <GameHeader>
         <HeaderContainer>
           <h3 data-testid="game-title">{game.title}</h3>
+          {signupAlwaysOpen && (
+            <SignupAlwaysOpenHelp>
+              {t("signup.signupAlwaysOpen")}
+            </SignupAlwaysOpenHelp>
+          )}
           <p>
             <RowItem>
               {t("signup.expectedDuration", {
@@ -301,4 +312,9 @@ const FavoriteIcon = styled(FontAwesomeIcon)`
 
 const RowItem = styled.span`
   padding-right: 12px;
+`;
+
+const SignupAlwaysOpenHelp = styled.span`
+  font-weight: 600;
+  margin-top: 10px;
 `;

--- a/shared/config/sharedConfig.ts
+++ b/shared/config/sharedConfig.ts
@@ -25,6 +25,7 @@ interface SharedConfig {
   PRE_SIGNUP_START: number;
   PHASE_GAP: number;
   directSignupWindows: Record<ProgramType, SignupWindow[]>;
+  directSignupAlwaysOpen: string[];
 }
 
 export const sharedConfig: SharedConfig = {
@@ -70,6 +71,8 @@ export const sharedConfig: SharedConfig = {
       },
     ],
   },
+
+  directSignupAlwaysOpen: ["p5344"], // PFS multi-table special: Pathfinder Society #3-99 Fate in the Future
 
   // Two phase signup settings
   PRE_SIGNUP_START: 60 * 4, // minutes

--- a/shared/utils/getDirectSignupStartTime.ts
+++ b/shared/utils/getDirectSignupStartTime.ts
@@ -7,7 +7,13 @@ export const getDirectSignupStartTime = (
   game: Game,
   timeNow: Dayjs
 ): string | null => {
-  const { directSignupWindows } = sharedConfig;
+  const { directSignupWindows, directSignupAlwaysOpen } = sharedConfig;
+
+  const signupAlwaysOpen = directSignupAlwaysOpen.includes(game.gameId);
+
+  if (signupAlwaysOpen) {
+    return null;
+  }
 
   const signupWindowsForProgramType = directSignupWindows[game.programType];
 


### PR DESCRIPTION
Add way to mark games as 'signup always open'

<img width="1059" alt="Screenshot 2022-07-12 at 21 14 46" src="https://user-images.githubusercontent.com/1327412/178565713-ebf3cc01-d436-4cf5-b784-0f4490196a17.png">
