### PR TITLE
Disable mongoose deprecation messages during tests

### DIFF
--- a/server/src/test/setupTests.ts
+++ b/server/src/test/setupTests.ts
@@ -1,4 +1,7 @@
+import mongoose from "mongoose";
 import { logger } from "server/utils/logger";
+
+mongoose.set("strictQuery", false);
 
 const throwOnErrorLog = false;
 


### PR DESCRIPTION
Uuden mongoose-version mukana tuli uusi deprecation-varoitus, että pitää eksplisiittisesti asettaa `strictQuery` arvo. Uusi versio tulee käyttämään `strictQuery: false` eli halutaan käyttää sitä.