### PR TITLE
Improve Sentry testing and move Sentry stuff to own file

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -60,7 +60,6 @@
     "@playwright/test": "1.30.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@ronilaukkarinen/stylelint-a11y": "1.2.4",
-    "@sentry/webpack-plugin": "1.20.0",
     "@stylelint/postcss-css-in-js": "0.38.0",
     "@types/dotenv-webpack": "7.0.3",
     "@types/react": "18.0.27",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -378,5 +378,10 @@
     "closePlayerList": "Close player list",
     "showPassword": "Show password",
     "hidePassword": "Hide password"
+  },
+  "admin": {
+    "sentryTesting": "Sentry testing",
+    "sentryClientTest": "Client test",
+    "sentryBackendTest": "Backend test"
   }
 }

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -378,5 +378,10 @@
     "closePlayerList": "Sulje pelaajalista",
     "showPassword": "Näytä salasana",
     "hidePassword": "Piilota salasana"
+  },
+  "admin": {
+    "sentryTesting": "Sentryn testaus",
+    "sentryClientTest": "Client-testi",
+    "sentryBackendTest": "Backend-testi"
   }
 }

--- a/client/src/views/admin/AdminView.tsx
+++ b/client/src/views/admin/AdminView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import styled, { css } from "styled-components";
 import { HiddenGamesList } from "client/views/admin/components/HiddenGamesList";
 import {
+  submitGetSentryTest,
   submitSignupTime,
   submitToggleAppOpen,
 } from "client/views/admin/adminThunks";
@@ -15,7 +16,6 @@ import { Button, ButtonStyle } from "client/components/Button";
 import { SignupQuestionList } from "client/views/admin/components/SignupQuestionList";
 import { Dropdown, Option } from "client/components/Dropdown";
 import { SignupStrategySelector } from "client/test/test-components/SignupStrategySelector";
-import { sharedConfig } from "shared/config/sharedConfig";
 import { ButtonGroup } from "client/components/ButtonGroup";
 
 export const AdminView = (): ReactElement => {
@@ -216,18 +216,27 @@ export const AdminView = (): ReactElement => {
         </>
       )}
 
-      {sharedConfig.enableSentryTesting && (
+      <h3>{t("admin.sentryTesting")}</h3>
+      <ButtonGroup>
         <Button
           buttonStyle={ButtonStyle.PRIMARY}
           onClick={() => {
-            const testValue = undefined;
+            const value = undefined;
             // @ts-expect-error: Sentry test value
-            console.log(testValue.value); // eslint-disable-line no-console
+            console.log(value.sentryTestValue); // eslint-disable-line no-console
           }}
         >
-          {t("button.close")}
+          {t("admin.sentryClientTest")}
         </Button>
-      )}
+        <Button
+          buttonStyle={ButtonStyle.PRIMARY}
+          onClick={async () => {
+            await dispatch(submitGetSentryTest());
+          }}
+        >
+          {t("admin.sentryBackendTest")}
+        </Button>
+      </ButtonGroup>
     </div>
   );
 };

--- a/client/src/views/admin/adminService.ts
+++ b/client/src/views/admin/adminService.ts
@@ -1,0 +1,6 @@
+import { api } from "client/utils/api";
+import { ApiEndpoint } from "shared/constants/apiEndpoints";
+
+export const getSentryTest = async (): Promise<void> => {
+  await api.get(ApiEndpoint.SENTRY_TEST);
+};

--- a/client/src/views/admin/adminThunks.ts
+++ b/client/src/views/admin/adminThunks.ts
@@ -19,6 +19,7 @@ import {
 import { SignupQuestion } from "shared/typings/models/settings";
 import { SignupStrategy } from "shared/config/sharedConfig.types";
 import { getSignupMessages } from "client/services/userServices";
+import { getSentryTest } from "client/views/admin/adminService";
 
 export const submitUpdateHidden = (hiddenGames: readonly Game[]): AppThunk => {
   return async (dispatch): Promise<void> => {
@@ -147,5 +148,11 @@ export const submitGetSignupMessages = (): AppThunk => {
     if (response?.status === "success") {
       dispatch(submitGetSignupMessagesAsync(response.signupMessages));
     }
+  };
+};
+
+export const submitGetSentryTest = (): AppThunk => {
+  return async (_dispatch): Promise<void> => {
+    await getSentryTest();
   };
 };

--- a/client/webpack.config.babel.ts
+++ b/client/webpack.config.babel.ts
@@ -7,7 +7,6 @@ import { Configuration } from "webpack";
 import "webpack-dev-server";
 import { merge } from "webpack-merge";
 import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
-import SentryCliPlugin from "@sentry/webpack-plugin";
 import { config } from "client/config";
 import { sharedConfig } from "shared/config/sharedConfig";
 
@@ -140,21 +139,6 @@ const prodConfig: Configuration = {
       test: /\.(js|html|svg)$/,
       threshold: 10240,
       minRatio: 0.8,
-    }),
-    new SentryCliPlugin({
-      include: "./build",
-      ignoreFile: ".sentrycliignore",
-      ignore: [
-        "node_modules",
-        "webpack.config.babel.ts",
-        ".eslintrc.js",
-        "babel.config.js",
-      ],
-      configFile: "sentry.properties",
-      errorHandler: (err, _invokeErr, compilation) => {
-        // @ts-expect-error: Types not available
-        compilation.warnings.push("Sentry CLI Plugin: " + err.message);
-      },
     }),
   ],
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "client": "yarn workspace konsti-client start",
     "copy-front": "rimraf server/front && ncp client/build server/front",
     "playwright": "yarn workspace konsti-client playwright",
-    "deploy:prod": "yarn build-front:prod && eb deploy konsti-docker-prod",
-    "deploy:staging": "yarn build-front:staging && eb deploy konsti-docker-staging",
     "docker-compose:start": "yarn build-front:dev && docker compose -f ./docker/docker-compose.yml up --detach --build --remove-orphans",
     "docker-compose:stop": "docker compose -f ./docker/docker-compose.yml down --remove-orphans",
     "docker-compose:test": "yarn build-front:ci && docker compose -f ./docker/docker-compose.yml -f ./client/playwright/docker-compose.yml up --attach playwright --attach server --build --remove-orphans --exit-code-from playwright --abort-on-container-exit",

--- a/server/src/api/apiRoutes.ts
+++ b/server/src/api/apiRoutes.ts
@@ -6,6 +6,7 @@ import {
   getResults,
   postAssignment,
 } from "server/features/results/resultsController";
+import { getSentryTest } from "server/features/sentry-tunnel/sentryTunnelController";
 import {
   deleteSignupQuestion,
   getSettings,
@@ -78,6 +79,7 @@ apiRoutes.get(ApiEndpoint.SETTINGS, getSettings);
 apiRoutes.get(ApiEndpoint.RESULTS, getResults);
 apiRoutes.get(ApiEndpoint.GROUP, getGroup);
 apiRoutes.get(ApiEndpoint.SIGNUP_MESSAGE, getSignupMessages);
+apiRoutes.get(ApiEndpoint.SENTRY_TEST, getSentryTest);
 
 /* DELETE routes */
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -34,6 +34,7 @@ interface Config {
   autoAssignInterval: string;
   useTestTime: boolean;
   localKompassiFile: string;
+  enableSentryInDev: boolean;
 }
 
 const commonConfig = {
@@ -65,6 +66,7 @@ const commonConfig = {
 
   // Testing
   localKompassiFile: "program-ropecon-2022-test.json",
+  enableSentryInDev: false,
 };
 
 const prodConfig = {

--- a/server/src/features/sentry-tunnel/sentryTunnelController.ts
+++ b/server/src/features/sentry-tunnel/sentryTunnelController.ts
@@ -2,6 +2,8 @@ import { Request, Response } from "express";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { resendSentryRequest } from "server/features/sentry-tunnel/sentryTunnelService";
+import { UserGroup } from "shared/typings/models/user";
+import { isAuthorized } from "server/utils/authHeader";
 
 export const postSentryTunnel = async (
   req: Request<{}, {}, null>,
@@ -12,4 +14,17 @@ export const postSentryTunnel = async (
   if (!req.body) return res.sendStatus(422);
   const response = await resendSentryRequest(req.body);
   return res.json(response);
+};
+
+export const getSentryTest = (
+  req: Request<{}, {}, null>,
+  res: Response
+): Response => {
+  logger.info(`API call: POST ${ApiEndpoint.SENTRY_TEST}`);
+
+  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN, "admin")) {
+    return res.sendStatus(401);
+  }
+
+  throw new Error("Test Sentry error");
 };

--- a/server/src/utils/sentry.ts
+++ b/server/src/utils/sentry.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/node";
 import * as Tracing from "@sentry/tracing";
 import express, { Express } from "express";
 import helmet from "helmet";
+import { config } from "server/config";
 import { postSentryTunnel } from "server/features/sentry-tunnel/sentryTunnelController";
 import { sharedConfig } from "shared/config/sharedConfig";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
@@ -59,6 +60,10 @@ const getDsn = (enableSentry: boolean): string | undefined => {
       return "https://0278d6bfb3f04c70acf826ecbd86ae58@o1321706.ingest.sentry.io/6579204";
     case "staging":
       return "https://ab176c60aac24be8af2f6c790f1437ac@o1321706.ingest.sentry.io/6578390";
+    case "development":
+      return config.enableSentryInDev
+        ? "https://6f41ef28d9664c1a8c3e25f58cecacf7@o1321706.ingest.sentry.io/6579493"
+        : undefined;
     default:
       return undefined;
   }

--- a/server/src/utils/sentry.ts
+++ b/server/src/utils/sentry.ts
@@ -1,0 +1,65 @@
+import * as Sentry from "@sentry/node";
+import * as Tracing from "@sentry/tracing";
+import express, { Express } from "express";
+import helmet from "helmet";
+import { postSentryTunnel } from "server/features/sentry-tunnel/sentryTunnelController";
+import { sharedConfig } from "shared/config/sharedConfig";
+import { ApiEndpoint } from "shared/constants/apiEndpoints";
+
+export const initSentry = (app: Express, enableSentry: boolean): void => {
+  Sentry.init({
+    dsn: getDsn(enableSentry),
+    integrations: [
+      // Enable HTTP calls tracing
+      new Sentry.Integrations.Http({ tracing: true }),
+      // Enable Express.js middleware tracing
+      new Tracing.Integrations.Express({
+        // To trace all requests to the default router
+        app,
+      }),
+    ],
+    tracesSampleRate: sharedConfig.tracesSampleRate,
+    environment: process.env.SETTINGS,
+  });
+
+  // The request handler must be the first middleware on the app
+  // RequestHandler creates a separate execution context using domains, so that every
+  // transaction/span/breadcrumb is attached to its own Hub instance
+  app.use(Sentry.Handlers.requestHandler());
+
+  // TracingHandler creates a trace for every incoming request
+  app.use(Sentry.Handlers.tracingHandler());
+
+  app.use(
+    helmet.contentSecurityPolicy({
+      directives: {
+        "connect-src": ["'self'", "*.sentry.io"],
+      },
+    })
+  );
+
+  // Sentry tunnel endpoint which accepts text/plain payload
+  app.post(
+    ApiEndpoint.SENTRY_TUNNEL,
+    express.text({
+      limit: "5000kb", // limit: 5MB
+      type: "text/plain",
+    }),
+    /* eslint-disable-next-line @typescript-eslint/no-misused-promises */
+    async (req, res) => {
+      await postSentryTunnel(req, res);
+    }
+  );
+};
+
+const getDsn = (enableSentry: boolean): string | undefined => {
+  if (!enableSentry) return undefined;
+  switch (process.env.SETTINGS) {
+    case "production":
+      return "https://0278d6bfb3f04c70acf826ecbd86ae58@o1321706.ingest.sentry.io/6579204";
+    case "staging":
+      return "https://ab176c60aac24be8af2f6c790f1437ac@o1321706.ingest.sentry.io/6578390";
+    default:
+      return undefined;
+  }
+};

--- a/shared/config/sharedConfig.ts
+++ b/shared/config/sharedConfig.ts
@@ -27,7 +27,6 @@ interface SharedConfig {
   directSignupWindows: Record<ProgramType, SignupWindow[]>;
   directSignupAlwaysOpen: string[];
   tracesSampleRate: number;
-  enableSentryTesting: boolean;
 }
 
 export const sharedConfig: SharedConfig = {
@@ -99,7 +98,6 @@ export const sharedConfig: SharedConfig = {
 
   // Sentry
   tracesSampleRate: 0.0,
-  enableSentryTesting: false,
 
   // Test values
   CONVENTION_START_TIME: "2022-07-29T12:00:00Z", // UTC date

--- a/shared/constants/apiEndpoints.ts
+++ b/shared/constants/apiEndpoints.ts
@@ -22,4 +22,5 @@ export enum ApiEndpoint {
   POPULATE_DB = "/api/populate-db",
   SIGNUP = "/api/signup",
   SENTRY_TUNNEL = "/api/sentry",
+  SENTRY_TEST = "/api/sentry-test",
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3049,23 +3049,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/cli@npm:^1.74.6":
-  version: 1.74.6
-  resolution: "@sentry/cli@npm:1.74.6"
-  dependencies:
-    https-proxy-agent: ^5.0.0
-    mkdirp: ^0.5.5
-    node-fetch: ^2.6.7
-    npmlog: ^4.1.2
-    progress: ^2.0.3
-    proxy-from-env: ^1.1.0
-    which: ^2.0.2
-  bin:
-    sentry-cli: bin/sentry-cli
-  checksum: 3d1ef94d5505ed23858503228b59ae1ed401774e27466d7a47eba47be3855e9706f12292d4a0a6135303a5916791620e0d3a184d2fda9e28f2d26ccd347b36fb
-  languageName: node
-  linkType: hard
-
 "@sentry/core@npm:7.36.0":
   version: 7.36.0
   resolution: "@sentry/core@npm:7.36.0"
@@ -3144,16 +3127,6 @@ __metadata:
     "@sentry/types": 7.36.0
     tslib: ^1.9.3
   checksum: 996831ae0895e7531b8a9119ebe5555b974d0b2193b9d143c87bb0ee620a4afe6515d0fda024454207ffcc24c366e7fcbe05e1cebc4e8344fdd6247334152244
-  languageName: node
-  linkType: hard
-
-"@sentry/webpack-plugin@npm:1.20.0":
-  version: 1.20.0
-  resolution: "@sentry/webpack-plugin@npm:1.20.0"
-  dependencies:
-    "@sentry/cli": ^1.74.6
-    webpack-sources: ^2.0.0 || ^3.0.0
-  checksum: d582026c3686f287ddc23de4e64c6f03afc2a73a84ec5a8fd3eded56a45683094bf132f4c624a35386fff872eb518771109d5c0b91a2cf79da0aff035c5bb05b
   languageName: node
   linkType: hard
 
@@ -4334,13 +4307,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "ansi-regex@npm:2.1.1"
-  checksum: 190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
-  languageName: node
-  linkType: hard
-
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -4397,13 +4363,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aproba@npm:^1.0.3":
-  version: 1.2.0
-  resolution: "aproba@npm:1.2.0"
-  checksum: 0fca141966559d195072ed047658b6e6c4fe92428c385dd38e288eacfc55807e7b4989322f030faff32c0f46bb0bc10f1e0ac32ec22d25315a1e5bbc0ebb76dc
-  languageName: node
-  linkType: hard
-
 "aproba@npm:^1.0.3 || ^2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
@@ -4418,16 +4377,6 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^3.6.0
   checksum: 52590c24860fa7173bedeb69a4c05fb573473e860197f618b9a28432ee4379049336727ae3a1f9c4cb083114601c1140cee578376164d0e651217a9843f9fe83
-  languageName: node
-  linkType: hard
-
-"are-we-there-yet@npm:~1.1.2":
-  version: 1.1.7
-  resolution: "are-we-there-yet@npm:1.1.7"
-  dependencies:
-    delegates: ^1.0.0
-    readable-stream: ^2.0.6
-  checksum: 70d251719c969b2745bfe5ddf3ebaefa846a636e90a6d5212573676af5d6670e15457761d4725731e19cbebdce42c4ab0cbedf23ab047f2a08274985aa10a3c7
   languageName: node
   linkType: hard
 
@@ -5382,13 +5331,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"code-point-at@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "code-point-at@npm:1.1.0"
-  checksum: 17d5666611f9b16d64fdf48176d9b7fb1c7d1c1607a189f7e600040a11a6616982876af148230336adb7d8fe728a559f743a4e29db3747e3b1a32fa7f4529681
-  languageName: node
-  linkType: hard
-
 "collect-v8-coverage@npm:^1.0.0":
   version: 1.0.1
   resolution: "collect-v8-coverage@npm:1.0.1"
@@ -5630,7 +5572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0, console-control-strings@npm:~1.1.0":
+"console-control-strings@npm:^1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 8755d76787f94e6cf79ce4666f0c5519906d7f5b02d4b884cf41e11dcd759ed69c57da0670afd9236d229a46e0f9cf519db0cd829c6dca820bb5a5c3def584ed
@@ -7673,22 +7615,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gauge@npm:~2.7.3":
-  version: 2.7.4
-  resolution: "gauge@npm:2.7.4"
-  dependencies:
-    aproba: ^1.0.3
-    console-control-strings: ^1.0.0
-    has-unicode: ^2.0.0
-    object-assign: ^4.1.0
-    signal-exit: ^3.0.0
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wide-align: ^1.1.0
-  checksum: a89b53cee65579b46832e050b5f3a79a832cc422c190de79c6b8e2e15296ab92faddde6ddf2d376875cbba2b043efa99b9e1ed8124e7365f61b04e3cee9d40ee
-  languageName: node
-  linkType: hard
-
 "generate-serial-number@npm:0.0.3":
   version: 0.0.3
   resolution: "generate-serial-number@npm:0.0.3"
@@ -7982,7 +7908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.0, has-unicode@npm:^2.0.1":
+"has-unicode@npm:^2.0.1":
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: 1eab07a7436512db0be40a710b29b5dc21fa04880b7f63c9980b706683127e3c1b57cb80ea96d47991bdae2dfe479604f6a1ba410106ee1046a41d1bd0814400
@@ -8597,15 +8523,6 @@ __metadata:
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
   checksum: df033653d06d0eb567461e58a7a8c9f940bd8c22274b94bf7671ab36df5719791aae15eef6d83bbb5e23283967f2f984b8914559d4449efda578c775c4be6f85
-  languageName: node
-  linkType: hard
-
-"is-fullwidth-code-point@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-fullwidth-code-point@npm:1.0.0"
-  dependencies:
-    number-is-nan: ^1.0.0
-  checksum: 4d46a7465a66a8aebcc5340d3b63a56602133874af576a9ca42c6f0f4bd787a743605771c5f246db77da96605fefeffb65fc1dbe862dcc7328f4b4d03edf5a57
   languageName: node
   linkType: hard
 
@@ -9672,7 +9589,6 @@ __metadata:
     "@reduxjs/toolkit": 1.9.2
     "@ronilaukkarinen/stylelint-a11y": 1.2.4
     "@sentry/react": 7.36.0
-    "@sentry/webpack-plugin": 1.20.0
     "@stylelint/postcss-css-in-js": 0.38.0
     "@types/dotenv-webpack": 7.0.3
     "@types/react": 18.0.27
@@ -10957,17 +10873,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^0.5.5":
-  version: 0.5.6
-  resolution: "mkdirp@npm:0.5.6"
-  dependencies:
-    minimist: ^1.2.6
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
-  languageName: node
-  linkType: hard
-
 "mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
@@ -11232,20 +11137,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.7":
-  version: 2.6.9
-  resolution: "node-fetch@npm:2.6.9"
-  dependencies:
-    whatwg-url: ^5.0.0
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
-  languageName: node
-  linkType: hard
-
 "node-forge@npm:^1":
   version: 1.3.1
   resolution: "node-forge@npm:1.3.1"
@@ -11349,18 +11240,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npmlog@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "npmlog@npm:4.1.2"
-  dependencies:
-    are-we-there-yet: ~1.1.2
-    console-control-strings: ~1.1.0
-    gauge: ~2.7.3
-    set-blocking: ~2.0.0
-  checksum: edbda9f95ec20957a892de1839afc6fb735054c3accf6fbefe767bac9a639fd5cea2baeac6bd2bcd50a85cb54924d57d9886c81c7fbc2332c2ddd19227504192
-  languageName: node
-  linkType: hard
-
 "npmlog@npm:^6.0.0":
   version: 6.0.2
   resolution: "npmlog@npm:6.0.2"
@@ -11382,13 +11261,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"number-is-nan@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "number-is-nan@npm:1.0.1"
-  checksum: 13656bc9aa771b96cef209ffca31c31a03b507ca6862ba7c3f638a283560620d723d52e626d57892c7fff475f4c36ac07f0600f14544692ff595abff214b9ffb
-  languageName: node
-  linkType: hard
-
 "nwsapi@npm:^2.2.2":
   version: 2.2.2
   resolution: "nwsapi@npm:2.2.2"
@@ -11396,7 +11268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4.0.1, object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
+"object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
@@ -12036,13 +11908,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "progress@npm:2.0.3"
-  checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
-  languageName: node
-  linkType: hard
-
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -12398,7 +12263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.6":
+"readable-stream@npm:^2.0.1":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
   dependencies:
@@ -13043,7 +12908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-blocking@npm:^2.0.0, set-blocking@npm:~2.0.0":
+"set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
@@ -13121,7 +12986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
@@ -13460,17 +13325,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "string-width@npm:1.0.2"
-  dependencies:
-    code-point-at: ^1.0.0
-    is-fullwidth-code-point: ^1.0.0
-    strip-ansi: ^3.0.0
-  checksum: 5c79439e95bc3bd7233a332c5f5926ab2ee90b23816ed4faa380ce3b2576d7800b0a5bb15ae88ed28737acc7ea06a518c2eef39142dd727adad0e45c776cd37e
-  languageName: node
-  linkType: hard
-
 "string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -13553,15 +13407,6 @@ __metadata:
   dependencies:
     safe-buffer: ~5.1.0
   checksum: 9ab7e56f9d60a28f2be697419917c50cac19f3e8e6c28ef26ed5f4852289fe0de5d6997d29becf59028556f2c62983790c1d9ba1e2a3cc401768ca12d5183a5b
-  languageName: node
-  linkType: hard
-
-"strip-ansi@npm:^3.0.0, strip-ansi@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "strip-ansi@npm:3.0.1"
-  dependencies:
-    ansi-regex: ^2.0.0
-  checksum: 9b974de611ce5075c70629c00fa98c46144043db92ae17748fb780f706f7a789e9989fd10597b7c2053ae8d1513fd707816a91f1879b2f71e6ac0b6a863db465
   languageName: node
   linkType: hard
 
@@ -14059,13 +13904,6 @@ __metadata:
   dependencies:
     punycode: ^2.1.1
   checksum: 44c3cc6767fb800490e6e9fd64fd49041aa4e49e1f6a012b34a75de739cc9ed3a6405296072c1df8b6389ae139c5e7c6496f659cfe13a04a4bff3a1422981270
-  languageName: node
-  linkType: hard
-
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
   languageName: node
   linkType: hard
 
@@ -14736,13 +14574,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
-  languageName: node
-  linkType: hard
-
 "webidl-conversions@npm:^7.0.0":
   version: 7.0.0
   resolution: "webidl-conversions@npm:7.0.0"
@@ -14871,7 +14702,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^2.0.0 || ^3.0.0, webpack-sources@npm:^3.2.3":
+"webpack-sources@npm:^3.2.3":
   version: 3.2.3
   resolution: "webpack-sources@npm:3.2.3"
   checksum: 989e401b9fe3536529e2a99dac8c1bdc50e3a0a2c8669cbafad31271eadd994bc9405f88a3039cd2e29db5e6d9d0926ceb7a1a4e7409ece021fe79c37d9c4607
@@ -14959,16 +14790,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: ~0.0.3
-    webidl-conversions: ^3.0.0
-  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
-  languageName: node
-  linkType: hard
-
 "which-boxed-primitive@npm:^1.0.2":
   version: 1.0.2
   resolution: "which-boxed-primitive@npm:1.0.2"
@@ -15030,7 +14851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.0, wide-align@npm:^1.1.5":
+"wide-align@npm:^1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
   dependencies:


### PR DESCRIPTION
* Lisätään admin-käliin painikkeet Sentryn client- ja bäkkäritestaamiseen. Käytännössä nää vaan aiheuttaa virheen joko frontissa tai bäkkärillä. Bäkkäritesti vaati uuden `/sentry-test` endpointin, mitä vain admin saa kutsua.
  ![image](https://user-images.githubusercontent.com/1327412/216838762-f13e6688-0577-42b9-8930-dd15d6c19200.png)
* Siirretään `server.ts` Sentryyn liittyvä koodi omaan tiedostoon `sentry.ts`
* Poistetaan Webpack-plugin, mitä käytettiin source mappien uploadaamiseen. Tehdään se jatkossa Github Actionilla.
* Lisätään asetus `enableSentryInDev: false` mikä määrittää, lähetetäänkö Sentry-virheitä dev-ympäristössä. Käytännössä virheitä halutaan lähettää vain Sentrya kehittäessä tai debugatessa. Dev-ympäristön source mappeja ei voi enää buildata, koska Webpack-plugin poistettiin, mutta tää ei ole ongelma, jos lähinnä testataan, että yhteys toimii.

TODO:
* Lisätään seuraavassa PR:ssä Github action Sentryn releasejen tekemiseen ja source mappien uploadaamiseen: https://github.com/marketplace/actions/sentry-release