### PR TITLE
Set Jest config workerIdleMemoryLimit

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@ import type { JestConfigWithTsJest } from "ts-jest";
 const jestConfig: JestConfigWithTsJest = {
   projects: ["client", "server"],
   coverageDirectory: "coverage",
+  workerIdleMemoryLimit: "1.5GB", // https://github.com/facebook/jest/issues/11956
 };
 
 /* eslint-disable-next-line import/no-unused-modules */


### PR DESCRIPTION
Set Jest config `workerIdleMemoryLimit` to fix memory leak issue:  https://jestjs.io/docs/configuration/#workeridlememorylimit-numberstring