### PR TITLE
Improve axios type usage

### DIFF
--- a/client/src/services/userServices.ts
+++ b/client/src/services/userServices.ts
@@ -5,6 +5,7 @@ import {
   GetUserBySerialResponse,
   GetUserResponse,
   PostUserError,
+  PostUserRequest,
   PostUserResponse,
 } from "shared/typings/api/users";
 import { RegistrationFormFields } from "client/views/registration/components/RegistrationForm";
@@ -18,11 +19,14 @@ export const postRegistration = async (
 ): Promise<PostUserResponse | PostUserError> => {
   const { username, password, serial } = registrationFormFields;
 
-  const response = await api.post<PostUserResponse>(ApiEndpoint.USERS, {
-    username,
-    password,
-    serial,
-  });
+  const response = await api.post<PostUserResponse, PostUserRequest>(
+    ApiEndpoint.USERS,
+    {
+      username,
+      password,
+      serial,
+    }
+  );
   return response.data;
 };
 

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -15,7 +15,7 @@ enum HttpMethod {
 }
 
 const axiosInstance: AxiosInstance = axios.create({
-  baseURL: `${config.apiServerUrl}`,
+  baseURL: config.apiServerUrl,
   timeout: 60000, // 60s
   headers: {
     "Content-Type": "application/json",

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import { t } from "i18next";
 import { config } from "client/config";
 import { getJWT } from "client/utils/getJWT";
@@ -14,7 +14,7 @@ enum HttpMethod {
   DELETE = "DELETE",
 }
 
-export const api: AxiosInstance = axios.create({
+const axiosInstance: AxiosInstance = axios.create({
   baseURL: `${config.apiServerUrl}`,
   timeout: 60000, // 60s
   headers: {
@@ -22,7 +22,8 @@ export const api: AxiosInstance = axios.create({
   },
 });
 
-api.interceptors.request.use((requestConfig) => {
+// Auth interceptor
+axiosInstance.interceptors.request.use((requestConfig) => {
   const authToken = getJWT();
   if (authToken && requestConfig.headers) {
     requestConfig.headers.Authorization = `Bearer ${authToken}`;
@@ -30,7 +31,8 @@ api.interceptors.request.use((requestConfig) => {
   return requestConfig;
 });
 
-api.interceptors.response.use(
+// Error interceptor
+axiosInstance.interceptors.response.use(
   (response) => response,
   (error) => {
     if (
@@ -89,4 +91,28 @@ const getErrorReason = (status: number): string => {
       // @ts-expect-error: i18next bug
       return t("error.unknown");
   }
+};
+
+export const api = {
+  post: async <RES = unknown, REQ = unknown, R = AxiosResponse<RES>>(
+    url: string,
+    data?: REQ,
+    axiosRequestConfig?: AxiosRequestConfig<REQ>
+  ): Promise<R> => {
+    return await axiosInstance.post(url, data, axiosRequestConfig);
+  },
+
+  get: async <T = unknown, D = unknown, R = AxiosResponse<T>>(
+    url: string,
+    axiosRequestConfig?: AxiosRequestConfig<D>
+  ): Promise<R> => {
+    return await axiosInstance.get(url, axiosRequestConfig);
+  },
+
+  delete: async <T = unknown, D = unknown, R = AxiosResponse<T>>(
+    url: string,
+    axiosRequestConfig?: AxiosRequestConfig<D>
+  ): Promise<R> => {
+    return await axiosInstance.get(url, axiosRequestConfig);
+  },
 };


### PR DESCRIPTION
Requestin datan tyypin antaminen on kömpelöä `axios` oman tyypityksen mukaan. Tehdään oma versio, mikä parantaa tyyppien passaamista. Tässä on aikaisemmin ollut aukko, että requestin tyyppiä ei ole käytetty clientin päässä vaikka aivan hyvin voisi.

Ennen:

```ts
  const response = await api.post<PostUserResponse, AxiosResponse<PostUserResponse>, PostUserRequest>(
    ApiEndpoint.USERS,
    {
      username,
      password,
      serial,
    }
  );
```

Jälkeen:

```ts
  const response = await api.post<PostUserResponse, PostUserRequest>(
    ApiEndpoint.USERS,
    {
      username,
      password,
      serial,
    }
  );
```