### PR TITLE
Add request types for all API requests

### DIFF
--- a/client/src/services/assignmentServices.ts
+++ b/client/src/services/assignmentServices.ts
@@ -1,16 +1,19 @@
 import { api } from "client/utils/api";
 import { ApiError } from "shared/typings/api/errors";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { PostPlayerAssignmentResponse } from "shared/typings/api/assignment";
+import {
+  PostPlayerAssignmentRequest,
+  PostPlayerAssignmentResponse,
+} from "shared/typings/api/assignment";
 
 export const postPlayerAssignment = async (
   signupTime: string
 ): Promise<PostPlayerAssignmentResponse | ApiError> => {
-  const response = await api.post<PostPlayerAssignmentResponse>(
-    ApiEndpoint.ASSIGNMENT,
-    {
-      startingTime: signupTime,
-    }
-  );
+  const response = await api.post<
+    PostPlayerAssignmentResponse,
+    PostPlayerAssignmentRequest
+  >(ApiEndpoint.ASSIGNMENT, {
+    startingTime: signupTime,
+  });
   return response.data;
 };

--- a/client/src/services/favoriteServices.ts
+++ b/client/src/services/favoriteServices.ts
@@ -2,14 +2,14 @@ import { api } from "client/utils/api";
 import { ApiError } from "shared/typings/api/errors";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
-  SaveFavoriteRequest,
+  PostFavoriteRequest,
   PostFavoriteResponse,
 } from "shared/typings/api/favorite";
 
 export const postFavorite = async (
-  favoriteData: SaveFavoriteRequest
+  favoriteData: PostFavoriteRequest
 ): Promise<PostFavoriteResponse | ApiError> => {
-  const response = await api.post<PostFavoriteResponse>(
+  const response = await api.post<PostFavoriteResponse, PostFavoriteRequest>(
     ApiEndpoint.FAVORITE,
     favoriteData
   );

--- a/client/src/services/feedbackServices.ts
+++ b/client/src/services/feedbackServices.ts
@@ -1,17 +1,23 @@
 import { api } from "client/utils/api";
 import { ApiError } from "shared/typings/api/errors";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { PostFeedbackResponse } from "shared/typings/api/feedback";
+import {
+  PostFeedbackRequest,
+  PostFeedbackResponse,
+} from "shared/typings/api/feedback";
 import { Feedback } from "shared/typings/models/feedback";
 
 export const postFeedback = async (
   feedbackData: Feedback
 ): Promise<PostFeedbackResponse | ApiError> => {
-  const response = await api.post<PostFeedbackResponse>(ApiEndpoint.FEEDBACK, {
-    feedback: feedbackData.feedback,
-    gameId: feedbackData.gameId,
-    username: feedbackData.username,
-  });
+  const response = await api.post<PostFeedbackResponse, PostFeedbackRequest>(
+    ApiEndpoint.FEEDBACK,
+    {
+      feedback: feedbackData.feedback,
+      gameId: feedbackData.gameId,
+      username: feedbackData.username,
+    }
+  );
 
   return response.data;
 };

--- a/client/src/services/gamesServices.ts
+++ b/client/src/services/gamesServices.ts
@@ -10,11 +10,13 @@ import { ApiEndpoint } from "shared/constants/apiEndpoints";
 export const postUpdateGames = async (): Promise<
   PostUpdateGamesResponse | PostUpdateGamesError
 > => {
-  const response = await api.post<PostUpdateGamesResponse>(ApiEndpoint.GAMES);
+  const response = await api.post<PostUpdateGamesResponse, {}>(
+    ApiEndpoint.GAMES
+  );
   return response.data;
 };
 
 export const getGames = async (): Promise<GetGamesResponse | ApiError> => {
-  const response = await api.get<GetGamesResponse>(ApiEndpoint.GAMES);
+  const response = await api.get<GetGamesResponse, {}>(ApiEndpoint.GAMES);
   return response.data;
 };

--- a/client/src/services/groupServices.test.ts
+++ b/client/src/services/groupServices.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { getGroup, postCreateGroup } from "client/services/groupServices";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { CreateGroupRequest } from "shared/typings/api/groups";
+import { PostCreateGroupRequest } from "shared/typings/api/groups";
 import { api } from "client/utils/api";
 
 test("GET group from server", async () => {
@@ -24,7 +24,7 @@ test("POST group to server", async () => {
     .spyOn(api, "post")
     .mockResolvedValue({ data: "test response" });
 
-  const groupRequest: CreateGroupRequest = {
+  const groupRequest: PostCreateGroupRequest = {
     groupCode: "123",
     username: "test user",
   };

--- a/client/src/services/groupServices.ts
+++ b/client/src/services/groupServices.ts
@@ -3,31 +3,35 @@ import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
   GetGroupError,
   GetGroupResponse,
-  CreateGroupRequest,
+  PostCreateGroupRequest,
   PostCreateGroupError,
-  PostGroupResponse,
-  JoinGroupRequest,
-  LeaveGroupRequest,
-  CloseGroupRequest,
+  PostJoinGroupRequest,
+  PostLeaveGroupRequest,
+  PostCloseGroupRequest,
   PostJoinGroupError,
   PostLeaveGroupError,
   PostCloseGroupError,
+  PostCreateGroupResponse,
+  PostJoinGroupResponse,
+  PostLeaveGroupResponse,
+  PostCloseGroupResponse,
+  GetGroupRequest,
 } from "shared/typings/api/groups";
 
 export const postCreateGroup = async (
-  groupRequest: CreateGroupRequest
-): Promise<PostGroupResponse | PostCreateGroupError> => {
-  const response = await api.post<PostGroupResponse>(
-    ApiEndpoint.GROUP,
-    groupRequest
-  );
+  groupRequest: PostCreateGroupRequest
+): Promise<PostCreateGroupResponse | PostCreateGroupError> => {
+  const response = await api.post<
+    PostCreateGroupResponse,
+    PostCreateGroupRequest
+  >(ApiEndpoint.GROUP, groupRequest);
   return response.data;
 };
 
 export const postJoinGroup = async (
-  groupRequest: JoinGroupRequest
-): Promise<PostGroupResponse | PostJoinGroupError> => {
-  const response = await api.post<PostGroupResponse>(
+  groupRequest: PostJoinGroupRequest
+): Promise<PostJoinGroupResponse | PostJoinGroupError> => {
+  const response = await api.post<PostJoinGroupResponse, PostJoinGroupRequest>(
     ApiEndpoint.JOIN_GROUP,
     groupRequest
   );
@@ -35,22 +39,22 @@ export const postJoinGroup = async (
 };
 
 export const postLeaveGroup = async (
-  groupRequest: LeaveGroupRequest
-): Promise<PostGroupResponse | PostLeaveGroupError> => {
-  const response = await api.post<PostGroupResponse>(
-    ApiEndpoint.LEAVE_GROUP,
-    groupRequest
-  );
+  groupRequest: PostLeaveGroupRequest
+): Promise<PostLeaveGroupResponse | PostLeaveGroupError> => {
+  const response = await api.post<
+    PostLeaveGroupResponse,
+    PostLeaveGroupRequest
+  >(ApiEndpoint.LEAVE_GROUP, groupRequest);
   return response.data;
 };
 
 export const postCloseGroup = async (
-  groupRequest: CloseGroupRequest
-): Promise<PostGroupResponse | PostCloseGroupError> => {
-  const response = await api.post<PostGroupResponse>(
-    ApiEndpoint.CLOSE_GROUP,
-    groupRequest
-  );
+  groupRequest: PostCloseGroupRequest
+): Promise<PostCloseGroupResponse | PostCloseGroupError> => {
+  const response = await api.post<
+    PostCloseGroupResponse,
+    PostLeaveGroupRequest
+  >(ApiEndpoint.CLOSE_GROUP, groupRequest);
   return response.data;
 };
 
@@ -58,11 +62,14 @@ export const getGroup = async (
   groupCode: string,
   username: string
 ): Promise<GetGroupResponse | GetGroupError> => {
-  const response = await api.get<GetGroupResponse>(ApiEndpoint.GROUP, {
-    params: {
-      groupCode,
-      username,
-    },
-  });
+  const response = await api.get<GetGroupResponse, GetGroupRequest>(
+    ApiEndpoint.GROUP,
+    {
+      params: {
+        groupCode,
+        username,
+      },
+    }
+  );
   return response.data;
 };

--- a/client/src/services/hiddenServices.ts
+++ b/client/src/services/hiddenServices.ts
@@ -2,13 +2,19 @@ import { api } from "client/utils/api";
 import { ApiError } from "shared/typings/api/errors";
 import { Game } from "shared/typings/models/game";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { PostHiddenResponse } from "shared/typings/api/settings";
+import {
+  PostHiddenRequest,
+  PostHiddenResponse,
+} from "shared/typings/api/settings";
 
 export const postHidden = async (
   hiddenData: readonly Game[]
 ): Promise<PostHiddenResponse | ApiError> => {
-  const response = await api.post<PostHiddenResponse>(ApiEndpoint.HIDDEN, {
-    hiddenData,
-  });
+  const response = await api.post<PostHiddenResponse, PostHiddenRequest>(
+    ApiEndpoint.HIDDEN,
+    {
+      hiddenData,
+    }
+  );
   return response.data;
 };

--- a/client/src/services/loginServices.ts
+++ b/client/src/services/loginServices.ts
@@ -1,28 +1,37 @@
 import { api } from "client/utils/api";
 import { LoginFormFields } from "client/views/login/components/LoginForm";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { PostLoginError, PostLoginResponse } from "shared/typings/api/login";
+import {
+  PostLoginError,
+  PostLoginRequest,
+  PostLoginResponse,
+  PostSessionRecoveryRequest,
+  PostSessionRecoveryResponse,
+} from "shared/typings/api/login";
 
 export const postLogin = async (
   loginFormFields: LoginFormFields
 ): Promise<PostLoginResponse | PostLoginError> => {
   const { username, password } = loginFormFields;
 
-  const response = await api.post<PostLoginResponse>(ApiEndpoint.LOGIN, {
-    username,
-    password,
-  });
+  const response = await api.post<PostLoginResponse, PostLoginRequest>(
+    ApiEndpoint.LOGIN,
+    {
+      username,
+      password,
+    }
+  );
   return response.data;
 };
 
 export const postSessionRecovery = async (
   jwt: string
 ): Promise<PostLoginResponse | PostLoginError> => {
-  const response = await api.post<PostLoginResponse>(
-    ApiEndpoint.SESSION_RESTORE,
-    {
-      jwt,
-    }
-  );
+  const response = await api.post<
+    PostSessionRecoveryResponse,
+    PostSessionRecoveryRequest
+  >(ApiEndpoint.SESSION_RESTORE, {
+    jwt,
+  });
   return response.data;
 };

--- a/client/src/services/myGamesServices.test.ts
+++ b/client/src/services/myGamesServices.test.ts
@@ -18,7 +18,5 @@ test("POST signed games to server", async () => {
 
   expect(response).toEqual("test response");
   expect(spy).toHaveBeenCalledTimes(1);
-  expect(spy).toHaveBeenCalledWith(ApiEndpoint.SIGNED_GAME, {
-    signupData,
-  });
+  expect(spy).toHaveBeenCalledWith(ApiEndpoint.SIGNED_GAME, signupData);
 });

--- a/client/src/services/myGamesServices.ts
+++ b/client/src/services/myGamesServices.ts
@@ -2,12 +2,13 @@ import { api } from "client/utils/api";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
   DeleteEnteredGameError,
-  DeleteEnteredGameParameters,
+  DeleteEnteredGameRequest,
   DeleteEnteredGameResponse,
   PostEnteredGameError,
-  PostEnteredGameParameters,
+  PostEnteredGameRequest,
   PostEnteredGameResponse,
   PostSignedGamesError,
+  PostSignedGamesRequest,
   PostSignedGamesResponse,
   SignupData,
 } from "shared/typings/api/myGames";
@@ -15,31 +16,31 @@ import {
 export const postSignedGames = async (
   signupData: SignupData
 ): Promise<PostSignedGamesResponse | PostSignedGamesError> => {
-  const response = await api.post<PostSignedGamesResponse>(
-    ApiEndpoint.SIGNED_GAME,
-    {
-      signupData,
-    }
-  );
+  const response = await api.post<
+    PostSignedGamesResponse,
+    PostSignedGamesRequest
+  >(ApiEndpoint.SIGNED_GAME, {
+    signupData,
+  });
   return response.data;
 };
 
 export const postEnteredGame = async (
-  requestData: PostEnteredGameParameters
+  requestData: PostEnteredGameRequest
 ): Promise<PostEnteredGameResponse | PostEnteredGameError> => {
-  const response = await api.post<PostEnteredGameResponse>(
-    ApiEndpoint.SIGNUP,
-    requestData
-  );
+  const response = await api.post<
+    PostEnteredGameResponse,
+    PostEnteredGameRequest
+  >(ApiEndpoint.SIGNUP, requestData);
   return response.data;
 };
 
 export const deleteEnteredGame = async (
-  requestData: DeleteEnteredGameParameters
+  requestData: DeleteEnteredGameRequest
 ): Promise<DeleteEnteredGameResponse | DeleteEnteredGameError> => {
-  const response = await api.delete<DeleteEnteredGameResponse>(
-    ApiEndpoint.SIGNUP,
-    { data: requestData }
-  );
+  const response = await api.delete<
+    DeleteEnteredGameResponse,
+    DeleteEnteredGameRequest
+  >(ApiEndpoint.SIGNUP, { data: requestData });
   return response.data;
 };

--- a/client/src/services/myGamesServices.ts
+++ b/client/src/services/myGamesServices.ts
@@ -10,18 +10,15 @@ import {
   PostSignedGamesError,
   PostSignedGamesRequest,
   PostSignedGamesResponse,
-  SignupData,
 } from "shared/typings/api/myGames";
 
 export const postSignedGames = async (
-  signupData: SignupData
+  signupData: PostSignedGamesRequest
 ): Promise<PostSignedGamesResponse | PostSignedGamesError> => {
   const response = await api.post<
     PostSignedGamesResponse,
     PostSignedGamesRequest
-  >(ApiEndpoint.SIGNED_GAME, {
-    signupData,
-  });
+  >(ApiEndpoint.SIGNED_GAME, signupData);
   return response.data;
 };
 

--- a/client/src/services/resultsServices.ts
+++ b/client/src/services/resultsServices.ts
@@ -1,16 +1,22 @@
 import { api } from "client/utils/api";
 import { ApiError } from "shared/typings/api/errors";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { GetResultsResponse } from "shared/typings/api/results";
+import {
+  GetResultsRequest,
+  GetResultsResponse,
+} from "shared/typings/api/results";
 
 export const getResults = async (
   startTime: string
 ): Promise<GetResultsResponse | ApiError> => {
-  const response = await api.get<GetResultsResponse>(ApiEndpoint.RESULTS, {
-    params: {
-      startTime,
-    },
-  });
+  const response = await api.get<GetResultsResponse, GetResultsRequest>(
+    ApiEndpoint.RESULTS,
+    {
+      params: {
+        startTime,
+      },
+    }
+  );
 
   return response.data;
 };

--- a/client/src/services/settingsServices.ts
+++ b/client/src/services/settingsServices.ts
@@ -2,9 +2,12 @@ import { api } from "client/utils/api";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { ApiError } from "shared/typings/api/errors";
 import {
+  DeleteSignupQuestionRequest,
+  DeleteSignupQuestionResponse,
   GetSettingsResponse,
   PostSettingsRequest,
   PostSettingsResponse,
+  PostSignupQuestionRequest,
   PostSignupQuestionResponse,
 } from "shared/typings/api/settings";
 import { SignupQuestion } from "shared/typings/models/settings";
@@ -12,14 +15,14 @@ import { SignupQuestion } from "shared/typings/models/settings";
 export const getSettings = async (): Promise<
   GetSettingsResponse | ApiError
 > => {
-  const response = await api.get<GetSettingsResponse>(ApiEndpoint.SETTINGS);
+  const response = await api.get<GetSettingsResponse, {}>(ApiEndpoint.SETTINGS);
   return response.data;
 };
 
 export const postSettings = async (
   settings: PostSettingsRequest
 ): Promise<PostSettingsResponse | ApiError> => {
-  const response = await api.post<PostSettingsResponse>(
+  const response = await api.post<PostSettingsResponse, PostSettingsRequest>(
     ApiEndpoint.SETTINGS,
     settings
   );
@@ -29,23 +32,23 @@ export const postSettings = async (
 export const postSignupQuestion = async (
   signupQuestion: SignupQuestion
 ): Promise<PostSignupQuestionResponse | ApiError> => {
-  const response = await api.post<PostSignupQuestionResponse>(
-    ApiEndpoint.SIGNUP_QUESTION,
-    {
-      signupQuestion,
-    }
-  );
+  const response = await api.post<
+    PostSignupQuestionResponse,
+    PostSignupQuestionRequest
+  >(ApiEndpoint.SIGNUP_QUESTION, {
+    signupQuestion,
+  });
   return response.data;
 };
 
 export const deleteSignupQuestion = async (
   gameId: string
-): Promise<PostSignupQuestionResponse | ApiError> => {
-  const response = await api.delete<PostSignupQuestionResponse>(
-    ApiEndpoint.SIGNUP_QUESTION,
-    {
-      data: { gameId },
-    }
-  );
+): Promise<DeleteSignupQuestionResponse | ApiError> => {
+  const response = await api.delete<
+    DeleteSignupQuestionResponse,
+    DeleteSignupQuestionRequest
+  >(ApiEndpoint.SIGNUP_QUESTION, {
+    data: { gameId },
+  });
   return response.data;
 };

--- a/client/src/services/userServices.ts
+++ b/client/src/services/userServices.ts
@@ -2,17 +2,19 @@ import { api } from "client/utils/api";
 import { ApiError } from "shared/typings/api/errors";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
+  GetSignupMessagesError,
+  GetSignupMessagesResponse,
+  GetUserBySerialRequest,
   GetUserBySerialResponse,
+  GetUserRequest,
   GetUserResponse,
+  PostUpdateUserPasswordRequest,
+  PostUpdateUserPasswordResponse,
   PostUserError,
   PostUserRequest,
   PostUserResponse,
 } from "shared/typings/api/users";
 import { RegistrationFormFields } from "client/views/registration/components/RegistrationForm";
-import {
-  GetSignupMessagesError,
-  GetSignupMessagesResponse,
-} from "shared/typings/models/signupMessage";
 
 export const postRegistration = async (
   registrationFormFields: RegistrationFormFields
@@ -33,25 +35,28 @@ export const postRegistration = async (
 export const getUser = async (
   username: string
 ): Promise<GetUserResponse | ApiError> => {
-  const response = await api.get<GetUserResponse>(ApiEndpoint.USERS, {
-    params: {
-      username,
-    },
-  });
+  const response = await api.get<GetUserResponse, GetUserRequest>(
+    ApiEndpoint.USERS,
+    {
+      params: {
+        username,
+      },
+    }
+  );
   return response.data;
 };
 
 export const getUserBySerialOrUsername = async (
   searchTerm: string
 ): Promise<GetUserBySerialResponse | ApiError> => {
-  const response = await api.get<GetUserBySerialResponse>(
-    ApiEndpoint.USERS_BY_SERIAL_OR_USERNAME,
-    {
-      params: {
-        searchTerm,
-      },
-    }
-  );
+  const response = await api.get<
+    GetUserBySerialResponse,
+    GetUserBySerialRequest
+  >(ApiEndpoint.USERS_BY_SERIAL_OR_USERNAME, {
+    params: {
+      searchTerm,
+    },
+  });
   return response.data;
 };
 
@@ -59,22 +64,22 @@ export const updateUserPassword = async (
   username: string,
   password: string,
   requester: string
-): Promise<PostUserResponse | ApiError> => {
-  const response = await api.post<PostUserResponse>(
-    ApiEndpoint.USERS_PASSWORD,
-    {
-      username,
-      password,
-      requester,
-    }
-  );
+): Promise<PostUpdateUserPasswordResponse | ApiError> => {
+  const response = await api.post<
+    PostUpdateUserPasswordResponse,
+    PostUpdateUserPasswordRequest
+  >(ApiEndpoint.USERS_PASSWORD, {
+    username,
+    password,
+    requester,
+  });
   return response.data;
 };
 
 export const getSignupMessages = async (): Promise<
   GetSignupMessagesResponse | GetSignupMessagesError
 > => {
-  const response = await api.get<GetSignupMessagesResponse>(
+  const response = await api.get<GetSignupMessagesResponse, {}>(
     ApiEndpoint.SIGNUP_MESSAGE
   );
   return response.data;

--- a/client/src/test/test-settings/testSettingsServices.ts
+++ b/client/src/test/test-settings/testSettingsServices.ts
@@ -3,13 +3,14 @@ import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { ApiError } from "shared/typings/api/errors";
 import {
   GetTestSettingsResponse,
+  PostTestSettingsRequest,
   PostTestSettingsResponse,
 } from "shared/test-typings/api/testSettings";
 
 export const getTestSettings = async (): Promise<
   GetTestSettingsResponse | ApiError
 > => {
-  const response = await api.get<GetTestSettingsResponse>(
+  const response = await api.get<GetTestSettingsResponse, {}>(
     ApiEndpoint.TEST_SETTINGS
   );
   return response.data;
@@ -20,11 +21,11 @@ export const postTestSettings = async ({
 }: {
   testTime: string;
 }): Promise<PostTestSettingsResponse | ApiError> => {
-  const response = await api.post<PostTestSettingsResponse>(
-    ApiEndpoint.TEST_SETTINGS,
-    {
-      testTime,
-    }
-  );
+  const response = await api.post<
+    PostTestSettingsResponse,
+    PostTestSettingsRequest
+  >(ApiEndpoint.TEST_SETTINGS, {
+    testTime,
+  });
   return response.data;
 };

--- a/client/src/typings/redux.typings.ts
+++ b/client/src/typings/redux.typings.ts
@@ -1,11 +1,10 @@
 import { ThunkAction } from "redux-thunk";
 import { Action } from "redux";
-import { Game, ProgramType } from "shared/typings/models/game";
+import { Game, ProgramType, UserSignup } from "shared/typings/models/game";
 import { GroupMember } from "shared/typings/models/groups";
 import { store, combinedReducer } from "client/utils/store";
 import { UserGames, UserGroup } from "shared/typings/models/user";
 import { SignupQuestion } from "shared/typings/models/settings";
-import { UserSignup } from "shared/typings/api/games";
 import { SignupStrategy } from "shared/config/sharedConfig.types";
 import { ErrorMessageType } from "client/components/ErrorBar";
 import { SignupMessage } from "shared/typings/models/signupMessage";

--- a/client/src/typings/redux.typings.ts
+++ b/client/src/typings/redux.typings.ts
@@ -1,13 +1,12 @@
 import { ThunkAction } from "redux-thunk";
 import { Action } from "redux";
 import { Game, ProgramType } from "shared/typings/models/game";
-import { GroupMember } from "shared/typings/api/groups";
+import { GroupMember } from "shared/typings/models/groups";
 import { store, combinedReducer } from "client/utils/store";
-import { UserGroup } from "shared/typings/models/user";
+import { UserGames, UserGroup } from "shared/typings/models/user";
 import { SignupQuestion } from "shared/typings/models/settings";
 import { UserSignup } from "shared/typings/api/games";
 import { SignupStrategy } from "shared/config/sharedConfig.types";
-import { UserGames } from "shared/typings/api/users";
 import { ErrorMessageType } from "client/components/ErrorBar";
 import { SignupMessage } from "shared/typings/models/signupMessage";
 

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -93,7 +93,7 @@ const getErrorReason = (status: number): string => {
   }
 };
 
-interface EnchancedAxiosRequestConfig<REQ> extends AxiosRequestConfig<REQ> {
+interface AxiosRequestConfigGet<REQ> extends AxiosRequestConfig<REQ> {
   params?: REQ;
 }
 
@@ -108,7 +108,7 @@ export const api = {
 
   get: async <RES = never, REQ = never, R = AxiosResponse<RES>>(
     url: string,
-    axiosRequestConfig?: EnchancedAxiosRequestConfig<REQ>
+    axiosRequestConfig?: AxiosRequestConfigGet<REQ>
   ): Promise<R> => {
     return await axiosInstance.get(url, axiosRequestConfig);
   },

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -93,8 +93,12 @@ const getErrorReason = (status: number): string => {
   }
 };
 
+interface EnchancedAxiosRequestConfig<REQ> extends AxiosRequestConfig<REQ> {
+  params?: REQ;
+}
+
 export const api = {
-  post: async <RES = unknown, REQ = unknown, R = AxiosResponse<RES>>(
+  post: async <RES = never, REQ = never, R = AxiosResponse<RES>>(
     url: string,
     data?: REQ,
     axiosRequestConfig?: AxiosRequestConfig<REQ>
@@ -102,16 +106,16 @@ export const api = {
     return await axiosInstance.post(url, data, axiosRequestConfig);
   },
 
-  get: async <T = unknown, D = unknown, R = AxiosResponse<T>>(
+  get: async <RES = never, REQ = never, R = AxiosResponse<RES>>(
     url: string,
-    axiosRequestConfig?: AxiosRequestConfig<D>
+    axiosRequestConfig?: EnchancedAxiosRequestConfig<REQ>
   ): Promise<R> => {
     return await axiosInstance.get(url, axiosRequestConfig);
   },
 
-  delete: async <T = unknown, D = unknown, R = AxiosResponse<T>>(
+  delete: async <RES = never, REQ = never, R = AxiosResponse<RES>>(
     url: string,
-    axiosRequestConfig?: AxiosRequestConfig<D>
+    axiosRequestConfig?: AxiosRequestConfig<REQ>
   ): Promise<R> => {
     return await axiosInstance.get(url, axiosRequestConfig);
   },

--- a/client/src/utils/getUpcomingGames.ts
+++ b/client/src/utils/getUpcomingGames.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { GroupMember } from "shared/typings/api/groups";
+import { GroupMember } from "shared/typings/models/groups";
 import { Game, ProgramType } from "shared/typings/models/game";
 import { getTime } from "client/utils/getTime";
 import { getIsGroupCreator } from "client/views/group/groupUtils";

--- a/client/src/views/all-games/allGamesSlice.ts
+++ b/client/src/views/all-games/allGamesSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { AllGamesState } from "client/typings/redux.typings";
-import { GameWithUsernames } from "shared/typings/api/games";
+import { GameWithUsernames } from "shared/typings/models/game";
 
 const initialState: AllGamesState = { games: [], signups: [] };
 

--- a/client/src/views/group/components/GroupMembersList.tsx
+++ b/client/src/views/group/components/GroupMembersList.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { GroupMember } from "shared/typings/api/groups";
+import { GroupMember } from "shared/typings/models/groups";
 
 interface Props {
   groupMembers: readonly GroupMember[];

--- a/client/src/views/group/groupSlice.ts
+++ b/client/src/views/group/groupSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { GroupState } from "client/typings/redux.typings";
-import { GroupMember } from "shared/typings/api/groups";
+import { GroupMember } from "shared/typings/models/groups";
 
 const initialState: GroupState = {
   groupCode: "0",

--- a/client/src/views/group/groupThunks.ts
+++ b/client/src/views/group/groupThunks.ts
@@ -12,10 +12,10 @@ import {
   submitUpdateGroupCodeAsync,
 } from "client/views/group/groupSlice";
 import {
-  CloseGroupRequest,
-  CreateGroupRequest,
-  JoinGroupRequest,
-  LeaveGroupRequest,
+  PostCloseGroupRequest,
+  PostCreateGroupRequest,
+  PostJoinGroupRequest,
+  PostLeaveGroupRequest,
 } from "shared/typings/api/groups";
 import { exhaustiveSwitchGuard } from "shared/utils/exhaustiveSwitchGuard";
 
@@ -26,7 +26,7 @@ export enum PostCreateGroupErrorMessage {
 }
 
 export const submitCreateGroup = (
-  group: CreateGroupRequest
+  group: PostCreateGroupRequest
 ): AppThunk<Promise<PostCreateGroupErrorMessage | undefined>> => {
   return async (dispatch): Promise<PostCreateGroupErrorMessage | undefined> => {
     const createGroupResponse = await postCreateGroup(group);
@@ -61,7 +61,7 @@ export enum PostJoinGroupErrorMessage {
 }
 
 export const submitJoinGroup = (
-  groupRequest: JoinGroupRequest
+  groupRequest: PostJoinGroupRequest
 ): AppThunk<Promise<PostJoinGroupErrorMessage | undefined>> => {
   return async (dispatch): Promise<PostJoinGroupErrorMessage | undefined> => {
     const joinGroupResponse = await postJoinGroup(groupRequest);
@@ -100,7 +100,7 @@ export enum PostLeaveGroupErrorMessage {
 }
 
 export const submitLeaveGroup = (
-  groupRequest: LeaveGroupRequest
+  groupRequest: PostLeaveGroupRequest
 ): AppThunk<Promise<PostLeaveGroupErrorMessage | undefined>> => {
   return async (dispatch): Promise<PostLeaveGroupErrorMessage | undefined> => {
     const leaveGroupResponse = await postLeaveGroup(groupRequest);
@@ -128,7 +128,7 @@ export enum PostCloseGroupErrorMessage {
 }
 
 export const submitCloseGroup = (
-  groupRequest: CloseGroupRequest
+  groupRequest: PostCloseGroupRequest
 ): AppThunk<Promise<PostCloseGroupErrorMessage | undefined>> => {
   return async (dispatch): Promise<PostCloseGroupErrorMessage | undefined> => {
     const leaveGroupResponse = await postCloseGroup(groupRequest);

--- a/client/src/views/my-games/myGamesSlice.ts
+++ b/client/src/views/my-games/myGamesSlice.ts
@@ -1,8 +1,7 @@
 import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { MyGamesState, RootState } from "client/typings/redux.typings";
-import { UserGames } from "shared/typings/api/users";
 import { Game, ProgramType } from "shared/typings/models/game";
-import { SelectedGame } from "shared/typings/models/user";
+import { SelectedGame, UserGames } from "shared/typings/models/user";
 
 const initialState: MyGamesState = {
   enteredGames: [],

--- a/client/src/views/my-games/myGamesThunks.ts
+++ b/client/src/views/my-games/myGamesThunks.ts
@@ -1,7 +1,7 @@
 import { getUser } from "client/services/userServices";
 import { postFavorite } from "client/services/favoriteServices";
 import { AppThunk } from "client/typings/redux.typings";
-import { SaveFavoriteRequest } from "shared/typings/api/favorite";
+import { PostFavoriteRequest } from "shared/typings/api/favorite";
 import {
   submitDeleteEnteredAsync,
   submitPostEnteredGameAsync,
@@ -10,8 +10,8 @@ import {
   submitUpdateFavoritesAsync,
 } from "client/views/my-games/myGamesSlice";
 import {
-  DeleteEnteredGameParameters,
-  PostEnteredGameParameters,
+  DeleteEnteredGameRequest,
+  PostEnteredGameRequest,
   SignupData,
 } from "shared/typings/api/myGames";
 import {
@@ -46,7 +46,7 @@ export const submitGetUser = (username: string): AppThunk => {
 };
 
 export const submitUpdateFavorites = (
-  favoriteData: SaveFavoriteRequest
+  favoriteData: PostFavoriteRequest
 ): AppThunk => {
   return async (dispatch): Promise<void> => {
     const updateFavoriteResponse = await postFavorite(favoriteData);
@@ -71,7 +71,7 @@ export enum PostEnteredGameErrorMessage {
 }
 
 export const submitPostEnteredGame = (
-  data: PostEnteredGameParameters
+  data: PostEnteredGameRequest
 ): AppThunk<Promise<PostEnteredGameErrorMessage | undefined>> => {
   return async (dispatch): Promise<PostEnteredGameErrorMessage | undefined> => {
     const signupResponse = await postEnteredGame(data);
@@ -103,7 +103,7 @@ export enum DeleteEnteredGameErrorMessage {
 }
 
 export const submitDeleteEnteredGame = (
-  data: DeleteEnteredGameParameters
+  data: DeleteEnteredGameRequest
 ): AppThunk<Promise<DeleteEnteredGameErrorMessage | undefined>> => {
   return async (
     dispatch

--- a/client/src/views/my-games/myGamesThunks.ts
+++ b/client/src/views/my-games/myGamesThunks.ts
@@ -12,7 +12,7 @@ import {
 import {
   DeleteEnteredGameRequest,
   PostEnteredGameRequest,
-  SignupData,
+  PostSignedGamesRequest,
 } from "shared/typings/api/myGames";
 import {
   deleteEnteredGame,
@@ -133,7 +133,7 @@ export enum PostSignedGamesErrorMessage {
 }
 
 export const submitPostSignedGames = (
-  signupData: SignupData
+  signupData: PostSignedGamesRequest
 ): AppThunk<Promise<PostSignedGamesErrorMessage | undefined>> => {
   return async (dispatch): Promise<PostSignedGamesErrorMessage | undefined> => {
     const signupResponse = await postSignedGames(signupData);

--- a/client/src/views/results/resultsUtils.ts
+++ b/client/src/views/results/resultsUtils.ts
@@ -1,5 +1,5 @@
 import { UsersForGame } from "client/typings/redux.typings";
-import { UserSignup } from "shared/typings/api/games";
+import { UserSignup } from "shared/typings/models/game";
 
 export const getUsersForGameId = (
   gameId: string,

--- a/server/src/api/apiRoutes.ts
+++ b/server/src/api/apiRoutes.ts
@@ -21,7 +21,7 @@ import { postFavorite } from "server/features/user/favorite-game/favoriteGameCon
 import {
   getGroup,
   postCloseGroup,
-  postGroup,
+  postCreateGroup,
   postJoinGroup,
   postLeaveGroup,
 } from "server/features/user/group/groupController";
@@ -56,7 +56,7 @@ apiRoutes.post(ApiEndpoint.SIGNED_GAME, postSignedGames);
 apiRoutes.post(ApiEndpoint.FAVORITE, postFavorite);
 apiRoutes.post(ApiEndpoint.HIDDEN, postHidden);
 apiRoutes.post(ApiEndpoint.FEEDBACK, postFeedback);
-apiRoutes.post(ApiEndpoint.GROUP, postGroup);
+apiRoutes.post(ApiEndpoint.GROUP, postCreateGroup);
 apiRoutes.post(ApiEndpoint.JOIN_GROUP, postJoinGroup);
 apiRoutes.post(ApiEndpoint.LEAVE_GROUP, postLeaveGroup);
 apiRoutes.post(ApiEndpoint.CLOSE_GROUP, postCloseGroup);

--- a/server/src/features/feedback/feedbackController.ts
+++ b/server/src/features/feedback/feedbackController.ts
@@ -4,17 +4,20 @@ import { UserGroup } from "shared/typings/models/user";
 import { storeFeedback } from "server/features/feedback/feedbackService";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { Feedback, FeedbackSchema } from "shared/typings/models/feedback";
+import {
+  PostFeedbackRequest,
+  PostFeedbackRequestSchema,
+} from "shared/typings/api/feedback";
 
 export const postFeedback = async (
-  req: Request<{}, {}, Feedback>,
+  req: Request<{}, {}, PostFeedbackRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.FEEDBACK}`);
 
   let parameters;
   try {
-    parameters = FeedbackSchema.parse(req.body);
+    parameters = PostFeedbackRequestSchema.parse(req.body);
   } catch (error) {
     return res.sendStatus(422);
   }

--- a/server/src/features/game/gameController.ts
+++ b/server/src/features/game/gameController.ts
@@ -5,7 +5,6 @@ import { fetchGames, updateGames } from "server/features/game/gamesService";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 
-// TODO: No body, should be GET
 export const postUpdateGames = async (
   req: Request<{}, {}, {}>,
   res: Response

--- a/server/src/features/game/gameController.ts
+++ b/server/src/features/game/gameController.ts
@@ -5,8 +5,9 @@ import { fetchGames, updateGames } from "server/features/game/gamesService";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 
+// TODO: No body, should be GET
 export const postUpdateGames = async (
-  req: Request,
+  req: Request<{}, {}, {}>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.GAMES}`);
@@ -20,7 +21,7 @@ export const postUpdateGames = async (
 };
 
 export const getGames = async (
-  _req: Request,
+  _req: Request<{}, {}, {}>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.GAMES}`);

--- a/server/src/features/game/gameUtils.ts
+++ b/server/src/features/game/gameUtils.ts
@@ -3,8 +3,11 @@ import dayjs, { Dayjs } from "dayjs";
 import { findGames, removeGames } from "server/features/game/gameRepository";
 import { GameDoc } from "server/typings/game.typings";
 import { logger } from "server/utils/logger";
-import { Game } from "shared/typings/models/game";
-import { GameWithUsernames, UserSignup } from "shared/typings/api/games";
+import {
+  Game,
+  GameWithUsernames,
+  UserSignup,
+} from "shared/typings/models/game";
 import { SignupStrategy } from "shared/config/sharedConfig.types";
 import { sharedConfig } from "shared/config/sharedConfig";
 import { findSettings } from "server/features/settings/settingsRepository";

--- a/server/src/features/results/resultsController.ts
+++ b/server/src/features/results/resultsController.ts
@@ -1,25 +1,28 @@
 import { Request, Response } from "express";
-import { z } from "zod";
 import { storeAssignment } from "server/features/player-assignment/assignmentController";
 import { fetchResults } from "server/features/results/resultsService";
 import { UserGroup } from "shared/typings/models/user";
 import { isAuthorized } from "server/utils/authHeader";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
+import {
+  PostPlayerAssignmentRequest,
+  PostPlayerAssignmentRequestSchema,
+} from "shared/typings/api/assignment";
+import {
+  GetResultsRequest,
+  GetResultsRequestSchema,
+} from "shared/typings/api/results";
 
 export const getResults = async (
-  req: Request,
+  req: Request<{}, {}, GetResultsRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.RESULTS}`);
 
-  const GetResultsQueryParameters = z.object({
-    startTime: z.string(),
-  });
-
   let parameters;
   try {
-    parameters = GetResultsQueryParameters.parse(req.query);
+    parameters = GetResultsRequestSchema.parse(req.query);
   } catch (error) {
     return res.sendStatus(422);
   }
@@ -35,7 +38,7 @@ export const getResults = async (
 };
 
 export const postAssignment = async (
-  req: Request<{}, {}, { startingTime: string }>,
+  req: Request<{}, {}, PostPlayerAssignmentRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.ASSIGNMENT}`);
@@ -44,13 +47,9 @@ export const postAssignment = async (
     return res.sendStatus(401);
   }
 
-  const PostAssignmentBody = z.object({
-    startingTime: z.string().min(1),
-  });
-
   let body;
   try {
-    body = PostAssignmentBody.parse(req.body);
+    body = PostPlayerAssignmentRequestSchema.parse(req.body);
   } catch (error) {
     logger.error(`Parsing postAssignment() request body failed: ${error}`);
     return res.sendStatus(422);

--- a/server/src/features/settings/settingsController.ts
+++ b/server/src/features/settings/settingsController.ts
@@ -11,15 +11,16 @@ import { UserGroup } from "shared/typings/models/user";
 import { isAuthorized } from "server/utils/authHeader";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { Game } from "shared/typings/models/game";
-import { SignupQuestion } from "shared/typings/models/settings";
 import {
+  DeleteSignupQuestionRequest,
+  PostHiddenRequest,
   PostSettingsRequest,
   PostSettingsRequestSchema,
+  PostSignupQuestionRequest,
 } from "shared/typings/api/settings";
 
 export const postHidden = async (
-  req: Request<{}, {}, { hiddenData: readonly Game[] }>,
+  req: Request<{}, {}, PostHiddenRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.HIDDEN}`);
@@ -34,7 +35,7 @@ export const postHidden = async (
 };
 
 export const getSettings = async (
-  _req: Request,
+  _req: Request<{}, {}, {}>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.SETTINGS}`);
@@ -44,7 +45,7 @@ export const getSettings = async (
 };
 
 export const postSignupQuestion = async (
-  req: Request<{}, {}, { signupQuestion: SignupQuestion }>,
+  req: Request<{}, {}, PostSignupQuestionRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNUP_QUESTION}`);
@@ -58,7 +59,7 @@ export const postSignupQuestion = async (
 };
 
 export const deleteSignupQuestion = async (
-  req: Request<{}, {}, { gameId: string }>,
+  req: Request<{}, {}, DeleteSignupQuestionRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: DELETE ${ApiEndpoint.SIGNUP_QUESTION}`);

--- a/server/src/features/signup/signupController.ts
+++ b/server/src/features/signup/signupController.ts
@@ -4,10 +4,10 @@ import { isAuthorized } from "server/utils/authHeader";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
-  DeleteEnteredGameParameters,
-  DeleteEnteredGameParametersSchema,
-  PostEnteredGameParameters,
-  PostEnteredGameParametersSchema,
+  DeleteEnteredGameRequest,
+  DeleteEnteredGameRequestSchema,
+  PostEnteredGameRequest,
+  PostEnteredGameRequestSchema,
 } from "shared/typings/api/myGames";
 import { UserGroup } from "shared/typings/models/user";
 import {
@@ -16,7 +16,7 @@ import {
 } from "server/features/signup/signupService";
 
 export const postSignup = async (
-  req: Request<{}, {}, PostEnteredGameParameters>,
+  req: Request<{}, {}, PostEnteredGameRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNUP}`);
@@ -28,7 +28,7 @@ export const postSignup = async (
   }
 
   try {
-    PostEnteredGameParametersSchema.parse(req.body);
+    PostEnteredGameRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.info(`Error validating postSignup parameters: ${error.message}`);
@@ -41,7 +41,7 @@ export const postSignup = async (
 };
 
 export const deleteSignup = async (
-  req: Request<{}, {}, DeleteEnteredGameParameters>,
+  req: Request<{}, {}, DeleteEnteredGameRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: DELETE ${ApiEndpoint.SIGNUP}`);
@@ -53,7 +53,7 @@ export const deleteSignup = async (
   }
 
   try {
-    DeleteEnteredGameParametersSchema.parse(req.body);
+    DeleteEnteredGameRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(

--- a/server/src/features/signup/signupRepository.ts
+++ b/server/src/features/signup/signupRepository.ts
@@ -4,8 +4,8 @@ import { SignupModel } from "server/features/signup/signupSchema";
 import { logger } from "server/utils/logger";
 import { sharedConfig } from "shared/config/sharedConfig";
 import {
-  DeleteEnteredGameParameters,
-  PostEnteredGameParameters,
+  DeleteEnteredGameRequest,
+  PostEnteredGameRequest,
 } from "shared/typings/api/myGames";
 import { ProgramType } from "shared/typings/models/game";
 
@@ -107,7 +107,7 @@ export const findUserSignups = async (username: string): Promise<Signup[]> => {
 };
 
 export const saveSignup = async (
-  signupsRequest: PostEnteredGameParameters
+  signupsRequest: PostEnteredGameRequest
 ): Promise<Signup> => {
   const { username, enteredGameId, startTime, message } = signupsRequest;
 
@@ -162,7 +162,7 @@ export const saveSignup = async (
 };
 
 export const delSignup = async (
-  signupRequest: DeleteEnteredGameParameters
+  signupRequest: DeleteEnteredGameRequest
 ): Promise<Signup> => {
   const { username, enteredGameId } = signupRequest;
 

--- a/server/src/features/signup/signupService.ts
+++ b/server/src/features/signup/signupService.ts
@@ -4,10 +4,10 @@ import { getTime } from "server/features/player-assignment/utils/getTime";
 import { isValidSignupTime } from "server/features/user/userUtils";
 import {
   DeleteEnteredGameError,
-  DeleteEnteredGameParameters,
+  DeleteEnteredGameRequest,
   DeleteEnteredGameResponse,
   PostEnteredGameError,
-  PostEnteredGameParameters,
+  PostEnteredGameRequest,
   PostEnteredGameResponse,
 } from "shared/typings/api/myGames";
 import { getDirectSignupStartTime } from "shared/utils/getDirectSignupStartTime";
@@ -16,7 +16,7 @@ import { delSignup, saveSignup } from "server/features/signup/signupRepository";
 import { findUser } from "server/features/user/userRepository";
 
 export const storeSignup = async (
-  signupRequest: PostEnteredGameParameters
+  signupRequest: PostEnteredGameRequest
 ): Promise<PostEnteredGameResponse | PostEnteredGameError> => {
   const { startTime, enteredGameId, username } = signupRequest;
   const timeNow = await getTime();
@@ -106,7 +106,7 @@ export const storeSignup = async (
 };
 
 export const removeSignup = async (
-  signupRequest: DeleteEnteredGameParameters
+  signupRequest: DeleteEnteredGameRequest
 ): Promise<DeleteEnteredGameResponse | DeleteEnteredGameError> => {
   const { startTime } = signupRequest;
 

--- a/server/src/features/statistics/fixer-helpers/formatFeedbacks.ts
+++ b/server/src/features/statistics/fixer-helpers/formatFeedbacks.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { logger } from "server/utils/logger";
 import { GameSchema } from "shared/typings/models/game";
 import { writeJson } from "server/features/statistics/statsUtil";
-import { FeedbackSchema } from "shared/typings/models/feedback";
+import { PostFeedbackRequestSchema } from "shared/typings/api/feedback";
 import { config } from "server/config";
 import { setLocale } from "shared/utils/setLocale";
 
@@ -17,7 +17,9 @@ export const formatFeedbacks = (year: number, event: string): void => {
     "utf8"
   );
 
-  const feedbacks = z.array(FeedbackSchema).parse(JSON.parse(feedbacksJson));
+  const feedbacks = z
+    .array(PostFeedbackRequestSchema)
+    .parse(JSON.parse(feedbacksJson));
 
   logger.info(`Loaded ${feedbacks.length} feedbacks`);
 

--- a/server/src/features/user/favorite-game/favoriteGameController.test.ts
+++ b/server/src/features/user/favorite-game/favoriteGameController.test.ts
@@ -11,7 +11,7 @@ import request from "supertest";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { startTestServer, stopTestServer } from "server/test/utils/testServer";
-import { SaveFavoriteRequest } from "shared/typings/api/favorite";
+import { PostFavoriteRequest } from "shared/typings/api/favorite";
 
 let mongoServer: MongoMemoryServer;
 
@@ -42,7 +42,7 @@ describe(`POST ${ApiEndpoint.FAVORITE}`, () => {
   test("should return 401 without valid authorization", async () => {
     const { server } = await startTestServer(mongoServer.getUri());
 
-    const saveFavoriteRequest: SaveFavoriteRequest = {
+    const saveFavoriteRequest: PostFavoriteRequest = {
       username: "testuser",
       favoritedGameIds: [],
     };

--- a/server/src/features/user/favorite-game/favoriteGameController.ts
+++ b/server/src/features/user/favorite-game/favoriteGameController.ts
@@ -1,26 +1,24 @@
 import { Request, Response } from "express";
-import { z, ZodError } from "zod";
+import { ZodError } from "zod";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { SaveFavoriteRequest } from "shared/typings/api/favorite";
+import {
+  PostFavoriteRequest,
+  PostFavoriteRequestSchema,
+} from "shared/typings/api/favorite";
 import { isAuthorized } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import { storeFavorite } from "server/features/user/favorite-game/favoriteGameService";
 
 export const postFavorite = async (
-  req: Request<{}, {}, { favoriteData: SaveFavoriteRequest }>,
+  req: Request<{}, {}, PostFavoriteRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.FAVORITE}`);
 
-  const PostFavoriteParameters = z.object({
-    username: z.string(),
-    favoritedGameIds: z.array(z.string()),
-  });
-
   let parameters;
   try {
-    parameters = PostFavoriteParameters.parse(req.body);
+    parameters = PostFavoriteRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(

--- a/server/src/features/user/favorite-game/favoriteGameRepository.ts
+++ b/server/src/features/user/favorite-game/favoriteGameRepository.ts
@@ -1,12 +1,12 @@
 import { findGames } from "server/features/game/gameRepository";
 import { UserModel } from "server/features/user/userSchema";
 import { logger } from "server/utils/logger";
-import { SaveFavoriteRequest } from "shared/typings/api/favorite";
+import { PostFavoriteRequest } from "shared/typings/api/favorite";
 import { Game } from "shared/typings/models/game";
 import { User } from "shared/typings/models/user";
 
 export const saveFavorite = async (
-  favoriteData: SaveFavoriteRequest
+  favoriteData: PostFavoriteRequest
 ): Promise<readonly Game[] | null> => {
   const { username, favoritedGameIds } = favoriteData;
 

--- a/server/src/features/user/favorite-game/favoriteGameService.ts
+++ b/server/src/features/user/favorite-game/favoriteGameService.ts
@@ -2,11 +2,11 @@ import { saveFavorite } from "server/features/user/favorite-game/favoriteGameRep
 import { ApiError } from "shared/typings/api/errors";
 import {
   PostFavoriteResponse,
-  SaveFavoriteRequest,
+  PostFavoriteRequest,
 } from "shared/typings/api/favorite";
 
 export const storeFavorite = async (
-  favoriteData: SaveFavoriteRequest
+  favoriteData: PostFavoriteRequest
 ): Promise<PostFavoriteResponse | ApiError> => {
   let favoritedGames;
   try {

--- a/server/src/features/user/group/groupController.test.ts
+++ b/server/src/features/user/group/groupController.test.ts
@@ -14,10 +14,10 @@ import { faker } from "@faker-js/faker";
 import dayjs from "dayjs";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
-  CloseGroupRequest,
-  CreateGroupRequest,
-  JoinGroupRequest,
-  LeaveGroupRequest,
+  PostCloseGroupRequest,
+  PostCreateGroupRequest,
+  PostJoinGroupRequest,
+  PostLeaveGroupRequest,
 } from "shared/typings/api/groups";
 import { UserGroup } from "shared/typings/models/user";
 import { getJWT } from "server/utils/jwt";
@@ -105,7 +105,7 @@ describe(`POST ${ApiEndpoint.GROUP}`, () => {
   });
 
   test("should return 401 without valid authorization", async () => {
-    const groupRequest: CreateGroupRequest = {
+    const groupRequest: PostCreateGroupRequest = {
       groupCode: "1234",
       username: "testuser",
     };
@@ -120,7 +120,7 @@ describe(`POST ${ApiEndpoint.GROUP}`, () => {
     const user = await saveUser(mockUser);
     expect(user.groupCode).toEqual("0");
 
-    const groupRequest: CreateGroupRequest = {
+    const groupRequest: PostCreateGroupRequest = {
       groupCode: mockUser.serial,
       username: mockUser.username,
     };
@@ -146,7 +146,7 @@ describe(`POST ${ApiEndpoint.JOIN_GROUP}`, () => {
   });
 
   test("should return 401 without valid authorization", async () => {
-    const groupRequest: JoinGroupRequest = {
+    const groupRequest: PostJoinGroupRequest = {
       groupCode: "1234",
       ownSerial: "1234",
       username: "testuser",
@@ -168,7 +168,7 @@ describe(`POST ${ApiEndpoint.JOIN_GROUP}`, () => {
     });
     expect(userWithSignups.signedGames.length).toEqual(2);
 
-    const groupRequest: JoinGroupRequest = {
+    const groupRequest: PostJoinGroupRequest = {
       groupCode: mockUser.serial,
       ownSerial: mockUser2.serial,
       username: mockUser2.username,
@@ -201,7 +201,7 @@ describe(`POST ${ApiEndpoint.JOIN_GROUP}`, () => {
       username: mockUser2.username,
     });
 
-    const groupRequest: JoinGroupRequest = {
+    const groupRequest: PostJoinGroupRequest = {
       groupCode: mockUser.serial,
       ownSerial: mockUser2.serial,
       username: mockUser2.username,
@@ -228,7 +228,7 @@ describe(`POST ${ApiEndpoint.LEAVE_GROUP}`, () => {
   });
 
   test("should return 401 without valid authorization", async () => {
-    const groupRequest: LeaveGroupRequest = {
+    const groupRequest: PostLeaveGroupRequest = {
       username: "testuser",
     };
 
@@ -242,7 +242,7 @@ describe(`POST ${ApiEndpoint.LEAVE_GROUP}`, () => {
     await saveUser({ ...mockUser, groupCode: mockUser.serial });
     await saveUser({ ...mockUser2, groupCode: mockUser.serial });
 
-    const groupRequest: LeaveGroupRequest = {
+    const groupRequest: PostLeaveGroupRequest = {
       username: mockUser2.username,
     };
 
@@ -267,7 +267,7 @@ describe(`POST ${ApiEndpoint.CLOSE_GROUP}`, () => {
   });
 
   test("should return 401 without valid authorization", async () => {
-    const groupRequest: CloseGroupRequest = {
+    const groupRequest: PostCloseGroupRequest = {
       groupCode: "1234",
       username: "testuser",
     };
@@ -282,7 +282,7 @@ describe(`POST ${ApiEndpoint.CLOSE_GROUP}`, () => {
     await saveUser({ ...mockUser, groupCode: mockUser.serial });
     await saveUser({ ...mockUser2, groupCode: mockUser.serial });
 
-    const groupRequest: CloseGroupRequest = {
+    const groupRequest: PostCloseGroupRequest = {
       groupCode: mockUser.serial,
       username: mockUser.username,
     };

--- a/server/src/features/user/group/groupController.ts
+++ b/server/src/features/user/group/groupController.ts
@@ -1,16 +1,18 @@
 import { Request, Response } from "express";
-import { z, ZodError } from "zod";
+import { ZodError } from "zod";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
-  CloseGroupRequest,
-  CloseGroupRequestSchema,
-  CreateGroupRequest,
-  CreateGroupRequestSchema,
-  JoinGroupRequest,
-  JoinGroupRequestSchema,
-  LeaveGroupRequest,
-  LeaveGroupRequestSchema,
+  GetGroupRequest,
+  GetGroupRequestSchema,
+  PostCloseGroupRequest,
+  PostCloseGroupRequestSchema,
+  PostCreateGroupRequest,
+  PostCreateGroupRequestSchema,
+  PostJoinGroupRequest,
+  PostJoinGroupRequestSchema,
+  PostLeaveGroupRequest,
+  PostLeaveGroupRequestSchema,
 } from "shared/typings/api/groups";
 import { isAuthorized } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
@@ -22,18 +24,20 @@ import {
   leaveGroup,
 } from "server/features/user/group/groupService";
 
-export const postGroup = async (
-  req: Request<{}, {}, CreateGroupRequest>,
+export const postCreateGroup = async (
+  req: Request<{}, {}, PostCreateGroupRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.GROUP}`);
 
-  let groupRequest: CreateGroupRequest;
+  let groupRequest: PostCreateGroupRequest;
   try {
-    groupRequest = CreateGroupRequestSchema.parse(req.body);
+    groupRequest = PostCreateGroupRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(`Error validating postGroup parameters: ${error.message}`);
+      logger.error(
+        `Error validating postCreateGroup parameters: ${error.message}`
+      );
     }
     return res.sendStatus(422);
   }
@@ -49,17 +53,19 @@ export const postGroup = async (
 };
 
 export const postJoinGroup = async (
-  req: Request<{}, {}, JoinGroupRequest>,
+  req: Request<{}, {}, PostJoinGroupRequest>,
   res: Response
 ): Promise<Response> => {
-  logger.info(`API call: POST ${ApiEndpoint.GROUP}`);
+  logger.info(`API call: POST ${ApiEndpoint.JOIN_GROUP}`);
 
-  let groupRequest: JoinGroupRequest;
+  let groupRequest: PostJoinGroupRequest;
   try {
-    groupRequest = JoinGroupRequestSchema.parse(req.body);
+    groupRequest = PostJoinGroupRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(`Error validating postGroup parameters: ${error.message}`);
+      logger.error(
+        `Error validating postJoinGroup parameters: ${error.message}`
+      );
     }
     return res.sendStatus(422);
   }
@@ -75,17 +81,19 @@ export const postJoinGroup = async (
 };
 
 export const postLeaveGroup = async (
-  req: Request<{}, {}, LeaveGroupRequest>,
+  req: Request<{}, {}, PostLeaveGroupRequest>,
   res: Response
 ): Promise<Response> => {
-  logger.info(`API call: POST ${ApiEndpoint.GROUP}`);
+  logger.info(`API call: POST ${ApiEndpoint.LEAVE_GROUP}`);
 
-  let groupRequest: LeaveGroupRequest;
+  let groupRequest: PostLeaveGroupRequest;
   try {
-    groupRequest = LeaveGroupRequestSchema.parse(req.body);
+    groupRequest = PostLeaveGroupRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(`Error validating postGroup parameters: ${error.message}`);
+      logger.error(
+        `Error validating postLeaveGroup parameters: ${error.message}`
+      );
     }
     return res.sendStatus(422);
   }
@@ -101,17 +109,19 @@ export const postLeaveGroup = async (
 };
 
 export const postCloseGroup = async (
-  req: Request<{}, {}, CloseGroupRequest>,
+  req: Request<{}, {}, PostCloseGroupRequest>,
   res: Response
 ): Promise<Response> => {
-  logger.info(`API call: POST ${ApiEndpoint.GROUP}`);
+  logger.info(`API call: POST ${ApiEndpoint.CLOSE_GROUP}`);
 
-  let groupRequest: CloseGroupRequest;
+  let groupRequest: PostCloseGroupRequest;
   try {
-    groupRequest = CloseGroupRequestSchema.parse(req.body);
+    groupRequest = PostCloseGroupRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(`Error validating postGroup parameters: ${error.message}`);
+      logger.error(
+        `Error validating postCloseGroup parameters: ${error.message}`
+      );
     }
     return res.sendStatus(422);
   }
@@ -127,19 +137,14 @@ export const postCloseGroup = async (
 };
 
 export const getGroup = async (
-  req: Request,
+  req: Request<{}, {}, GetGroupRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.GROUP}`);
 
-  const GetGroupQueryParameters = z.object({
-    groupCode: z.string(),
-    username: z.string(),
-  });
-
   let parameters;
   try {
-    parameters = GetGroupQueryParameters.parse(req.query);
+    parameters = GetGroupRequestSchema.parse(req.query);
   } catch (error) {
     return res.sendStatus(422);
   }

--- a/server/src/features/user/group/groupService.ts
+++ b/server/src/features/user/group/groupService.ts
@@ -11,15 +11,18 @@ import { findUserSerial } from "server/features/user/userRepository";
 import { logger } from "server/utils/logger";
 import { sharedConfig } from "shared/config/sharedConfig";
 import {
+  PostCloseGroupResponse,
+  PostCreateGroupResponse,
   GetGroupError,
   GetGroupResponse,
-  GroupMember,
+  PostJoinGroupResponse,
+  PostLeaveGroupResponse,
   PostCloseGroupError,
   PostCreateGroupError,
-  PostGroupResponse,
   PostJoinGroupError,
   PostLeaveGroupError,
 } from "shared/typings/api/groups";
+import { GroupMember } from "shared/typings/models/groups";
 import { User } from "shared/typings/models/user";
 
 const { directSignupAlwaysOpenIds } = sharedConfig;
@@ -27,7 +30,7 @@ const { directSignupAlwaysOpenIds } = sharedConfig;
 export const createGroup = async (
   username: string,
   groupCode: string
-): Promise<PostGroupResponse | PostCreateGroupError> => {
+): Promise<PostCreateGroupResponse | PostCreateGroupError> => {
   let signups;
   try {
     signups = await findUserSignups(username);
@@ -113,7 +116,7 @@ export const joinGroup = async (
   username: string,
   groupCode: string,
   ownSerial: string
-): Promise<PostGroupResponse | PostJoinGroupError> => {
+): Promise<PostJoinGroupResponse | PostJoinGroupError> => {
   // Cannot join own group
   if (ownSerial === groupCode) {
     return {
@@ -244,7 +247,7 @@ export const joinGroup = async (
 
 export const leaveGroup = async (
   username: string
-): Promise<PostGroupResponse | PostLeaveGroupError> => {
+): Promise<PostLeaveGroupResponse | PostLeaveGroupError> => {
   let saveGroupResponse;
   try {
     saveGroupResponse = await saveGroupCode("0", username);
@@ -275,7 +278,7 @@ export const leaveGroup = async (
 export const closeGroup = async (
   groupCode: string,
   username: string
-): Promise<PostGroupResponse | PostCloseGroupError> => {
+): Promise<PostCloseGroupResponse | PostCloseGroupError> => {
   let groupMembers;
   try {
     groupMembers = await findGroupMembers(groupCode);

--- a/server/src/features/user/login/loginController.ts
+++ b/server/src/features/user/login/loginController.ts
@@ -1,9 +1,12 @@
 import { Request, Response } from "express";
-import { ZodError, z } from "zod";
+import { ZodError } from "zod";
 import { login } from "server/features/user/login/loginService";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { PostLoginRequest } from "shared/typings/api/login";
+import {
+  PostLoginRequest,
+  PostLoginRequestSchema,
+} from "shared/typings/api/login";
 
 export const postLogin = async (
   req: Request<{}, {}, PostLoginRequest>,
@@ -11,14 +14,9 @@ export const postLogin = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.LOGIN}`);
 
-  const PostLoginParameters = z.object({
-    username: z.string(),
-    password: z.string(),
-  });
-
   let parameters;
   try {
-    parameters = PostLoginParameters.parse(req.body);
+    parameters = PostLoginRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(`Error validating postLogin parameters: ${error.message}`);

--- a/server/src/features/user/session-restore/sessionRestoreController.ts
+++ b/server/src/features/user/session-restore/sessionRestoreController.ts
@@ -2,10 +2,10 @@ import { Request, Response } from "express";
 import { loginWithJwt } from "server/features/user/session-restore/sessionRestoreService";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { SessionRecoveryRequest } from "shared/typings/api/login";
+import { PostSessionRecoveryRequest } from "shared/typings/api/login";
 
 export const postSessionRestore = async (
-  req: Request<{}, {}, SessionRecoveryRequest>,
+  req: Request<{}, {}, PostSessionRecoveryRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SESSION_RESTORE}`);

--- a/server/src/features/user/signed-game/signedGameController.test.ts
+++ b/server/src/features/user/signed-game/signedGameController.test.ts
@@ -51,9 +51,7 @@ describe(`POST ${ApiEndpoint.SIGNED_GAME}`, () => {
     try {
       const response = await request(server)
         .post(ApiEndpoint.SIGNED_GAME)
-        .send({
-          signupData,
-        });
+        .send(signupData);
       expect(response.status).toEqual(401);
     } finally {
       await stopTestServer(server);

--- a/server/src/features/user/signed-game/signedGameController.test.ts
+++ b/server/src/features/user/signed-game/signedGameController.test.ts
@@ -11,7 +11,7 @@ import request from "supertest";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { startTestServer, stopTestServer } from "server/test/utils/testServer";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { SignupData } from "shared/typings/api/myGames";
+import { PostSignedGamesRequest } from "shared/typings/api/myGames";
 
 let mongoServer: MongoMemoryServer;
 
@@ -42,7 +42,7 @@ describe(`POST ${ApiEndpoint.SIGNED_GAME}`, () => {
   test("should return 401 without valid authorization", async () => {
     const { server } = await startTestServer(mongoServer.getUri());
 
-    const signupData: SignupData = {
+    const signupData: PostSignedGamesRequest = {
       username: "testuser",
       selectedGames: [],
       startTime: "2019-11-23T08:00:00Z",

--- a/server/src/features/user/signed-game/signedGameController.ts
+++ b/server/src/features/user/signed-game/signedGameController.ts
@@ -28,7 +28,7 @@ export const postSignedGames = async (
     return res.sendStatus(422);
   }
 
-  const { selectedGames, username, startTime } = parameters.signupData;
+  const { selectedGames, username, startTime } = parameters;
 
   if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
     return res.sendStatus(401);

--- a/server/src/features/user/signed-game/signedGameController.ts
+++ b/server/src/features/user/signed-game/signedGameController.ts
@@ -1,37 +1,24 @@
 import { Request, Response } from "express";
-import { z, ZodError } from "zod";
+import { ZodError } from "zod";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { SignupData } from "shared/typings/api/myGames";
-import { GameSchema } from "shared/typings/models/game";
+import {
+  PostSignedGamesRequest,
+  PostSignedGamesRequestSchema,
+} from "shared/typings/api/myGames";
 import { isAuthorized } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import { storeSignedGames } from "server/features/user/signed-game/signedGameService";
 
-const PostSignedGamesParameters = z.object({
-  signupData: z.object({
-    username: z.string(),
-    selectedGames: z.array(
-      z.object({
-        gameDetails: GameSchema,
-        priority: z.number(),
-        time: z.string(),
-        message: z.string(),
-      })
-    ),
-    startTime: z.string(),
-  }),
-});
-
 export const postSignedGames = async (
-  req: Request<{}, {}, { signupData: SignupData }>,
+  req: Request<{}, {}, PostSignedGamesRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNED_GAME}`);
 
   let parameters;
   try {
-    parameters = PostSignedGamesParameters.parse(req.body);
+    parameters = PostSignedGamesRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(

--- a/server/src/features/user/signup-message/signupMessageController.ts
+++ b/server/src/features/user/signup-message/signupMessageController.ts
@@ -6,7 +6,7 @@ import { UserGroup } from "shared/typings/models/user";
 import { fetchSignupMessages } from "server/features/user/signup-message/signupMessageService";
 
 export const getSignupMessages = async (
-  req: Request,
+  req: Request<{}, {}, {}>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.SIGNUP_MESSAGE}`);

--- a/server/src/features/user/signup-message/signupMessageService.ts
+++ b/server/src/features/user/signup-message/signupMessageService.ts
@@ -1,11 +1,11 @@
 import { findSettings } from "server/features/settings/settingsRepository";
 import { Signup } from "server/features/signup/signup.typings";
 import { findSignups } from "server/features/signup/signupRepository";
-import { Settings } from "shared/typings/models/settings";
 import {
   GetSignupMessagesError,
   GetSignupMessagesResponse,
-} from "shared/typings/models/signupMessage";
+} from "shared/typings/api/users";
+import { Settings } from "shared/typings/models/settings";
 
 export const fetchSignupMessages = async (): Promise<
   GetSignupMessagesResponse | GetSignupMessagesError

--- a/server/src/features/user/userController.ts
+++ b/server/src/features/user/userController.ts
@@ -10,7 +10,6 @@ import { UserGroup } from "shared/typings/models/user";
 import { isAuthorized } from "server/utils/authHeader";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { UpdateUserPasswordRequest } from "shared/typings/api/login";
 import { sharedConfig } from "shared/config/sharedConfig";
 import { createSerial } from "./userUtils";
 import {
@@ -19,7 +18,15 @@ import {
   USERNAME_LENGTH_MAX,
   USERNAME_LENGTH_MIN,
 } from "shared/constants/validation";
-import { PostUserRequest } from "shared/typings/api/users";
+import {
+  GetUserBySerialRequest,
+  GetUserBySerialRequestSchema,
+  GetUserRequest,
+  GetUserRequestSchema,
+  PostUserRequest,
+  PostUpdateUserPasswordRequest,
+  PostUpdateUserPasswordRequestSchema,
+} from "shared/typings/api/users";
 
 export const postUser = async (
   req: Request<{}, {}, PostUserRequest>,
@@ -74,20 +81,14 @@ export const postUser = async (
 };
 
 export const postUserPassword = async (
-  req: Request<{}, {}, UpdateUserPasswordRequest>,
+  req: Request<{}, {}, PostUpdateUserPasswordRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.USERS_PASSWORD}`);
 
-  const PostUserPasswordParameters = z.object({
-    username: z.string(),
-    password: z.string(),
-    requester: z.string(),
-  });
-
   let parameters;
   try {
-    parameters = PostUserPasswordParameters.parse(req.body);
+    parameters = PostUpdateUserPasswordRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(
@@ -118,18 +119,14 @@ export const postUserPassword = async (
 };
 
 export const getUser = async (
-  req: Request,
+  req: Request<{}, {}, GetUserRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.USERS}`);
 
-  const GetUserQueryParameters = z.object({
-    username: z.string(),
-  });
-
   let parameters;
   try {
-    parameters = GetUserQueryParameters.parse(req.query);
+    parameters = GetUserRequestSchema.parse(req.query);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(`Error validating getUser parameters: ${error.message}`);
@@ -153,7 +150,7 @@ export const getUser = async (
 };
 
 export const getUserBySerialOrUsername = async (
-  req: Request,
+  req: Request<{}, {}, GetUserBySerialRequest>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.USERS_BY_SERIAL_OR_USERNAME}`);
@@ -174,13 +171,9 @@ export const getUserBySerialOrUsername = async (
     return res.sendStatus(401);
   }
 
-  const GetUserQueryParameters = z.object({
-    searchTerm: z.string(),
-  });
-
   let parameters;
   try {
-    parameters = GetUserQueryParameters.parse(req.query);
+    parameters = GetUserBySerialRequestSchema.parse(req.query);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(

--- a/server/src/features/user/userController.ts
+++ b/server/src/features/user/userController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { z, ZodError } from "zod";
+import { ZodError } from "zod";
 import {
   fetchUserByUsername,
   storeUser,
@@ -13,12 +13,6 @@ import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { sharedConfig } from "shared/config/sharedConfig";
 import { createSerial } from "./userUtils";
 import {
-  PASSWORD_LENGTH_MAX,
-  PASSWORD_LENGTH_MIN,
-  USERNAME_LENGTH_MAX,
-  USERNAME_LENGTH_MIN,
-} from "shared/constants/validation";
-import {
   GetUserBySerialRequest,
   GetUserBySerialRequestSchema,
   GetUserRequest,
@@ -26,6 +20,7 @@ import {
   PostUserRequest,
   PostUpdateUserPasswordRequest,
   PostUpdateUserPasswordRequestSchema,
+  PostUserRequestSchema,
 } from "shared/typings/api/users";
 
 export const postUser = async (
@@ -34,33 +29,9 @@ export const postUser = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.USERS}`);
 
-  const PostUserParameters = z.object({
-    username: z
-      .string()
-      .trim()
-      .min(USERNAME_LENGTH_MIN)
-      .max(USERNAME_LENGTH_MAX),
-    password: z
-      .string()
-      .trim()
-      .min(PASSWORD_LENGTH_MIN)
-      .max(PASSWORD_LENGTH_MAX),
-    serial: z
-      .string()
-      .optional()
-      .refine((input) => {
-        if (sharedConfig.requireRegistrationCode) {
-          if (!input || input.trim().length === 0) {
-            return false;
-          }
-        }
-        return true;
-      }),
-  });
-
   let parameters;
   try {
-    parameters = PostUserParameters.parse(req.body);
+    parameters = PostUserRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(`Error validating postUser parameters: ${error.message}`);

--- a/server/src/test/mock-data/mockUser.ts
+++ b/server/src/test/mock-data/mockUser.ts
@@ -1,7 +1,7 @@
 import { testGame, testGame2 } from "shared/tests/testGame";
 import { NewUser } from "server/typings/user.typings";
 import { SelectedGame, UserGroup } from "shared/typings/models/user";
-import { PostEnteredGameParameters } from "shared/typings/api/myGames";
+import { PostEnteredGameRequest } from "shared/typings/api/myGames";
 
 export const mockUser: NewUser = {
   username: "Test User",
@@ -58,14 +58,14 @@ export const mockSignedGames: readonly SelectedGame[] = [
   },
 ];
 
-export const mockPostEnteredGameRequest: PostEnteredGameParameters = {
+export const mockPostEnteredGameRequest: PostEnteredGameRequest = {
   username: mockUser.username,
   enteredGameId: testGame.gameId,
   startTime: testGame.startTime,
   message: "",
 };
 
-export const mockPostEnteredGameRequest2: PostEnteredGameParameters = {
+export const mockPostEnteredGameRequest2: PostEnteredGameRequest = {
   username: mockUser.username,
   enteredGameId: testGame2.gameId,
   startTime: testGame2.startTime,

--- a/server/src/test/test-data-generation/testDataController.ts
+++ b/server/src/test/test-data-generation/testDataController.ts
@@ -5,7 +5,7 @@ import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { runGenerators } from "server/test/test-data-generation/runGenerators";
 
 export const postPopulateDb = async (
-  _req: Request<{}, {}, null>,
+  _req: Request<{}, {}, {}>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.POPULATE_DB}`);

--- a/shared/typings/api/assignment.ts
+++ b/shared/typings/api/assignment.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { Result } from "shared/typings/models/result";
 
+// POST player assignment
+
 export const PostPlayerAssignmentRequestSchema = z.object({
   startingTime: z.string().min(1),
 });

--- a/shared/typings/api/assignment.ts
+++ b/shared/typings/api/assignment.ts
@@ -1,4 +1,13 @@
+import { z } from "zod";
 import { Result } from "shared/typings/models/result";
+
+export const PostPlayerAssignmentRequestSchema = z.object({
+  startingTime: z.string().min(1),
+});
+
+export type PostPlayerAssignmentRequest = z.infer<
+  typeof PostPlayerAssignmentRequestSchema
+>;
 
 export interface PostPlayerAssignmentResponse {
   message: string;

--- a/shared/typings/api/favorite.ts
+++ b/shared/typings/api/favorite.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { Game } from "shared/typings/models/game";
 
+// POST favorite
+
 export const PostFavoriteRequestSchema = z.object({
   username: z.string(),
   favoritedGameIds: z.array(z.string()),

--- a/shared/typings/api/favorite.ts
+++ b/shared/typings/api/favorite.ts
@@ -1,12 +1,15 @@
+import { z } from "zod";
 import { Game } from "shared/typings/models/game";
+
+export const PostFavoriteRequestSchema = z.object({
+  username: z.string(),
+  favoritedGameIds: z.array(z.string()),
+});
+
+export type PostFavoriteRequest = z.infer<typeof PostFavoriteRequestSchema>;
 
 export interface PostFavoriteResponse {
   favoritedGames: readonly Game[];
   message: string;
   status: "success";
-}
-
-export interface SaveFavoriteRequest {
-  username: string;
-  favoritedGameIds: readonly string[];
 }

--- a/shared/typings/api/feedback.ts
+++ b/shared/typings/api/feedback.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+// POST feedback
+
 export const PostFeedbackRequestSchema = z.object({
   gameId: z.string(),
   feedback: z.string(),

--- a/shared/typings/api/feedback.ts
+++ b/shared/typings/api/feedback.ts
@@ -1,3 +1,13 @@
+import { z } from "zod";
+
+export const PostFeedbackRequestSchema = z.object({
+  gameId: z.string(),
+  feedback: z.string(),
+  username: z.string(),
+});
+
+export type PostFeedbackRequest = z.infer<typeof PostFeedbackRequestSchema>;
+
 export interface PostFeedbackResponse {
   message: string;
   status: "success";

--- a/shared/typings/api/games.ts
+++ b/shared/typings/api/games.ts
@@ -1,5 +1,7 @@
 import { ApiError } from "shared/typings/api/errors";
-import { Game } from "shared/typings/models/game";
+import { Game, GameWithUsernames } from "shared/typings/models/game";
+
+// POST update games
 
 export interface PostUpdateGamesResponse {
   message: string;
@@ -11,6 +13,8 @@ export interface PostUpdateGamesError extends ApiError {
   errorId: "unknown";
 }
 
+// GET games
+
 export interface GetGamesResponse {
   message: string;
   status: "success";
@@ -19,14 +23,4 @@ export interface GetGamesResponse {
 
 export interface GetGamesError extends ApiError {
   errorId: "unknown";
-}
-
-export interface GameWithUsernames {
-  game: Game;
-  users: UserSignup[];
-}
-
-export interface UserSignup {
-  username: string;
-  signupMessage: string;
 }

--- a/shared/typings/api/groups.ts
+++ b/shared/typings/api/groups.ts
@@ -1,8 +1,19 @@
 import { z } from "zod";
-import { SelectedGame } from "shared/typings/models/user";
 import { ApiError } from "shared/typings/api/errors";
+import { GroupMember } from "shared/typings/models/groups";
 
-export interface PostGroupResponse {
+// POST: Create group
+
+export const PostCreateGroupRequestSchema = z.object({
+  groupCode: z.string(),
+  username: z.string(),
+});
+
+export type PostCreateGroupRequest = z.infer<
+  typeof PostCreateGroupRequestSchema
+>;
+
+export interface PostCreateGroupResponse {
   groupCode: string;
   message: string;
   status: "success";
@@ -10,6 +21,22 @@ export interface PostGroupResponse {
 
 export interface PostCreateGroupError extends ApiError {
   errorId: "unknown" | "groupExists" | "userHasSignedGames";
+}
+
+// POST: Join group
+
+export const PostJoinGroupRequestSchema = z.object({
+  groupCode: z.string(),
+  ownSerial: z.string(),
+  username: z.string(),
+});
+
+export type PostJoinGroupRequest = z.infer<typeof PostJoinGroupRequestSchema>;
+
+export interface PostJoinGroupResponse {
+  groupCode: string;
+  message: string;
+  status: "success";
 }
 
 export interface PostJoinGroupError extends ApiError {
@@ -22,13 +49,51 @@ export interface PostJoinGroupError extends ApiError {
     | "userHasSignedGames";
 }
 
+// POST: Leave group
+
+export const PostLeaveGroupRequestSchema = z.object({
+  username: z.string(),
+});
+
+export type PostLeaveGroupRequest = z.infer<typeof PostLeaveGroupRequestSchema>;
+
+export interface PostLeaveGroupResponse {
+  groupCode: string;
+  message: string;
+  status: "success";
+}
+
 export interface PostLeaveGroupError extends ApiError {
   errorId: "unknown" | "failedToLeave";
+}
+
+// POST: Close group
+
+export const PostCloseGroupRequestSchema = z.object({
+  groupCode: z.string(),
+  username: z.string(),
+});
+
+export type PostCloseGroupRequest = z.infer<typeof PostCloseGroupRequestSchema>;
+
+export interface PostCloseGroupResponse {
+  groupCode: string;
+  message: string;
+  status: "success";
 }
 
 export interface PostCloseGroupError extends ApiError {
   errorId: "unknown" | "onlyCreatorCanCloseGroup";
 }
+
+// GET group
+
+export const GetGroupRequestSchema = z.object({
+  groupCode: z.string(),
+  username: z.string(),
+});
+
+export type GetGroupRequest = z.infer<typeof GetGroupRequestSchema>;
 
 export interface GetGroupResponse {
   message: string;
@@ -38,39 +103,4 @@ export interface GetGroupResponse {
 
 export interface GetGroupError extends ApiError {
   errorId: "unknown";
-}
-
-export const CreateGroupRequestSchema = z.object({
-  groupCode: z.string(),
-  username: z.string(),
-});
-
-export type CreateGroupRequest = z.infer<typeof CreateGroupRequestSchema>;
-
-export const JoinGroupRequestSchema = z.object({
-  groupCode: z.string(),
-  ownSerial: z.string(),
-  username: z.string(),
-});
-
-export type JoinGroupRequest = z.infer<typeof JoinGroupRequestSchema>;
-
-export const LeaveGroupRequestSchema = z.object({
-  username: z.string(),
-});
-
-export type LeaveGroupRequest = z.infer<typeof LeaveGroupRequestSchema>;
-
-export const CloseGroupRequestSchema = z.object({
-  groupCode: z.string(),
-  username: z.string(),
-});
-
-export type CloseGroupRequest = z.infer<typeof CloseGroupRequestSchema>;
-
-export interface GroupMember {
-  groupCode: string;
-  serial: string;
-  signedGames: readonly SelectedGame[];
-  username: string;
 }

--- a/shared/typings/api/groups.ts
+++ b/shared/typings/api/groups.ts
@@ -33,11 +33,7 @@ export const PostJoinGroupRequestSchema = z.object({
 
 export type PostJoinGroupRequest = z.infer<typeof PostJoinGroupRequestSchema>;
 
-export interface PostJoinGroupResponse {
-  groupCode: string;
-  message: string;
-  status: "success";
-}
+export type PostJoinGroupResponse = PostCreateGroupResponse;
 
 export interface PostJoinGroupError extends ApiError {
   errorId:
@@ -57,11 +53,7 @@ export const PostLeaveGroupRequestSchema = z.object({
 
 export type PostLeaveGroupRequest = z.infer<typeof PostLeaveGroupRequestSchema>;
 
-export interface PostLeaveGroupResponse {
-  groupCode: string;
-  message: string;
-  status: "success";
-}
+export type PostLeaveGroupResponse = PostCreateGroupResponse;
 
 export interface PostLeaveGroupError extends ApiError {
   errorId: "unknown" | "failedToLeave";
@@ -76,11 +68,7 @@ export const PostCloseGroupRequestSchema = z.object({
 
 export type PostCloseGroupRequest = z.infer<typeof PostCloseGroupRequestSchema>;
 
-export interface PostCloseGroupResponse {
-  groupCode: string;
-  message: string;
-  status: "success";
-}
+export type PostCloseGroupResponse = PostCreateGroupResponse;
 
 export interface PostCloseGroupError extends ApiError {
   errorId: "unknown" | "onlyCreatorCanCloseGroup";

--- a/shared/typings/api/login.ts
+++ b/shared/typings/api/login.ts
@@ -1,10 +1,13 @@
+import { z } from "zod";
 import { ApiError } from "shared/typings/api/errors";
 import { UserGroup } from "shared/typings/models/user";
 
-export interface PostLoginRequest {
-  username: string;
-  password: string;
-}
+export const PostLoginRequestSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+});
+
+export type PostLoginRequest = z.infer<typeof PostLoginRequestSchema>;
 
 export interface PostLoginResponse {
   groupCode: string;
@@ -20,11 +23,8 @@ export interface PostLoginError extends ApiError {
   errorId: "unknown" | "loginFailed" | "loginDisabled";
 }
 
-export interface SessionRecoveryRequest {
+export interface PostSessionRecoveryRequest {
   jwt: string;
 }
 
-export interface UpdateUserPasswordRequest {
-  username: string;
-  password: string;
-}
+export type PostSessionRecoveryResponse = PostLoginResponse;

--- a/shared/typings/api/login.ts
+++ b/shared/typings/api/login.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import { ApiError } from "shared/typings/api/errors";
 import { UserGroup } from "shared/typings/models/user";
 
+// POST login
+
 export const PostLoginRequestSchema = z.object({
   username: z.string(),
   password: z.string(),
@@ -22,6 +24,8 @@ export interface PostLoginResponse {
 export interface PostLoginError extends ApiError {
   errorId: "unknown" | "loginFailed" | "loginDisabled";
 }
+
+// POST session recovery
 
 export interface PostSessionRecoveryRequest {
   jwt: string;

--- a/shared/typings/api/myGames.ts
+++ b/shared/typings/api/myGames.ts
@@ -4,6 +4,8 @@ import { ApiError } from "shared/typings/api/errors";
 import { SelectedGame } from "shared/typings/models/user";
 import { GameSchema } from "shared/typings/models/game";
 
+// POST signed games
+
 export const PostSignedGamesRequestSchema = z.object({
   signupData: z.object({
     username: z.string(),
@@ -39,6 +41,8 @@ export interface PostSignedGamesError extends ApiError {
   errorId: "unknown" | "signupEnded" | "samePriority";
 }
 
+// POST entered game
+
 export const PostEnteredGameRequestSchema = z.object({
   username: z.string(),
   enteredGameId: z.string(),
@@ -59,6 +63,8 @@ export interface PostEnteredGameResponse {
 export interface PostEnteredGameError extends ApiError {
   errorId: "unknown" | "gameFull" | "signupEnded" | "signupNotOpenYet";
 }
+
+// DELETE entered game
 
 export const DeleteEnteredGameRequestSchema = z.object({
   username: z.string(),

--- a/shared/typings/api/myGames.ts
+++ b/shared/typings/api/myGames.ts
@@ -7,25 +7,17 @@ import { GameSchema } from "shared/typings/models/game";
 // POST signed games
 
 export const PostSignedGamesRequestSchema = z.object({
-  signupData: z.object({
-    username: z.string(),
-    selectedGames: z.array(
-      z.object({
-        gameDetails: GameSchema,
-        priority: z.number(),
-        time: z.string(),
-        message: z.string(),
-      })
-    ),
-    startTime: z.string(),
-  }),
+  username: z.string(),
+  selectedGames: z.array(
+    z.object({
+      gameDetails: GameSchema,
+      priority: z.number(),
+      time: z.string(),
+      message: z.string(),
+    })
+  ),
+  startTime: z.string(),
 });
-
-export interface SignupData {
-  username: string;
-  selectedGames: SelectedGame[];
-  startTime: string;
-}
 
 export type PostSignedGamesRequest = z.infer<
   typeof PostSignedGamesRequestSchema

--- a/shared/typings/api/myGames.ts
+++ b/shared/typings/api/myGames.ts
@@ -2,6 +2,32 @@ import { z } from "zod";
 import { SIGNUP_MESSAGE_LENGTH } from "shared/constants/validation";
 import { ApiError } from "shared/typings/api/errors";
 import { SelectedGame } from "shared/typings/models/user";
+import { GameSchema } from "shared/typings/models/game";
+
+export const PostSignedGamesRequestSchema = z.object({
+  signupData: z.object({
+    username: z.string(),
+    selectedGames: z.array(
+      z.object({
+        gameDetails: GameSchema,
+        priority: z.number(),
+        time: z.string(),
+        message: z.string(),
+      })
+    ),
+    startTime: z.string(),
+  }),
+});
+
+export interface SignupData {
+  username: string;
+  selectedGames: SelectedGame[];
+  startTime: string;
+}
+
+export type PostSignedGamesRequest = z.infer<
+  typeof PostSignedGamesRequestSchema
+>;
 
 export interface PostSignedGamesResponse {
   message: string;
@@ -13,11 +39,16 @@ export interface PostSignedGamesError extends ApiError {
   errorId: "unknown" | "signupEnded" | "samePriority";
 }
 
-export interface SignupData {
-  username: string;
-  selectedGames: readonly SelectedGame[];
-  startTime: string;
-}
+export const PostEnteredGameRequestSchema = z.object({
+  username: z.string(),
+  enteredGameId: z.string(),
+  startTime: z.string(),
+  message: z.string().max(SIGNUP_MESSAGE_LENGTH, "Message too long"),
+});
+
+export type PostEnteredGameRequest = z.infer<
+  typeof PostEnteredGameRequestSchema
+>;
 
 export interface PostEnteredGameResponse {
   message: string;
@@ -29,32 +60,21 @@ export interface PostEnteredGameError extends ApiError {
   errorId: "unknown" | "gameFull" | "signupEnded" | "signupNotOpenYet";
 }
 
-export interface DeleteEnteredGameError extends ApiError {
-  errorId: "unknown" | "signupEnded";
-}
+export const DeleteEnteredGameRequestSchema = z.object({
+  username: z.string(),
+  enteredGameId: z.string(),
+  startTime: z.string(),
+});
+
+export type DeleteEnteredGameRequest = z.infer<
+  typeof DeleteEnteredGameRequestSchema
+>;
 
 export interface DeleteEnteredGameResponse {
   message: string;
   status: "success";
 }
 
-export const PostEnteredGameParametersSchema = z.object({
-  username: z.string(),
-  enteredGameId: z.string(),
-  startTime: z.string(),
-  message: z.string().max(SIGNUP_MESSAGE_LENGTH, "Message too long"),
-});
-
-export type PostEnteredGameParameters = z.infer<
-  typeof PostEnteredGameParametersSchema
->;
-
-export const DeleteEnteredGameParametersSchema = z.object({
-  username: z.string(),
-  enteredGameId: z.string(),
-  startTime: z.string(),
-});
-
-export type DeleteEnteredGameParameters = z.infer<
-  typeof DeleteEnteredGameParametersSchema
->;
+export interface DeleteEnteredGameError extends ApiError {
+  errorId: "unknown" | "signupEnded";
+}

--- a/shared/typings/api/results.ts
+++ b/shared/typings/api/results.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { Result } from "shared/typings/models/result";
 
+// GET results
+
 export const GetResultsRequestSchema = z.object({
   startTime: z.string(),
 });

--- a/shared/typings/api/results.ts
+++ b/shared/typings/api/results.ts
@@ -1,4 +1,11 @@
+import { z } from "zod";
 import { Result } from "shared/typings/models/result";
+
+export const GetResultsRequestSchema = z.object({
+  startTime: z.string(),
+});
+
+export type GetResultsRequest = z.infer<typeof GetResultsRequestSchema>;
 
 export interface GetResultsResponse {
   message: string;

--- a/shared/typings/api/settings.ts
+++ b/shared/typings/api/settings.ts
@@ -7,6 +7,8 @@ import {
   SignupQuestion,
 } from "shared/typings/models/settings";
 
+// POST hidden
+
 export interface PostHiddenRequest {
   hiddenData: readonly Game[];
 }
@@ -17,6 +19,8 @@ export interface PostHiddenResponse {
   status: "success";
 }
 
+// GET settings
+
 export interface GetSettingsResponse {
   appOpen: boolean;
   hiddenGames: readonly Game[];
@@ -25,6 +29,8 @@ export interface GetSettingsResponse {
   signupQuestions: readonly SignupQuestion[];
   signupStrategy: SignupStrategy;
 }
+
+// POST signup question
 
 export interface PostSignupQuestionRequest {
   signupQuestion: SignupQuestion;
@@ -36,11 +42,15 @@ export interface PostSignupQuestionResponse {
   status: "success";
 }
 
+// DELETE signup question
+
 export interface DeleteSignupQuestionRequest {
   gameId: string;
 }
 
 export type DeleteSignupQuestionResponse = PostSignupQuestionResponse;
+
+// POST settings
 
 export const PostSettingsRequestSchema = SettingsSchema.partial();
 

--- a/shared/typings/api/settings.ts
+++ b/shared/typings/api/settings.ts
@@ -7,6 +7,10 @@ import {
   SignupQuestion,
 } from "shared/typings/models/settings";
 
+export interface PostHiddenRequest {
+  hiddenData: readonly Game[];
+}
+
 export interface PostHiddenResponse {
   hiddenGames: readonly Game[];
   message: string;
@@ -22,11 +26,21 @@ export interface GetSettingsResponse {
   signupStrategy: SignupStrategy;
 }
 
+export interface PostSignupQuestionRequest {
+  signupQuestion: SignupQuestion;
+}
+
 export interface PostSignupQuestionResponse {
   signupQuestions: readonly SignupQuestion[];
   message: string;
   status: "success";
 }
+
+export interface DeleteSignupQuestionRequest {
+  gameId: string;
+}
+
+export type DeleteSignupQuestionResponse = PostSignupQuestionResponse;
 
 export const PostSettingsRequestSchema = SettingsSchema.partial();
 

--- a/shared/typings/api/users.ts
+++ b/shared/typings/api/users.ts
@@ -1,6 +1,13 @@
+import { z } from "zod";
 import { ApiError } from "shared/typings/api/errors";
-import { Game } from "shared/typings/models/game";
-import { SelectedGame } from "shared/typings/models/user";
+import { SignupMessage } from "shared/typings/models/signupMessage";
+import { UserGames } from "shared/typings/models/user";
+
+export const GetUserRequestSchema = z.object({
+  username: z.string(),
+});
+
+export type GetUserRequest = z.infer<typeof GetUserRequestSchema>;
 
 export interface GetUserResponse {
   games: UserGames;
@@ -27,6 +34,26 @@ export interface PostUserError extends ApiError {
   errorId: "unknown" | "invalidSerial" | "usernameNotFree";
 }
 
+export const PostUpdateUserPasswordRequestSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+  requester: z.string(),
+});
+
+export type PostUpdateUserPasswordRequest = z.infer<
+  typeof PostUpdateUserPasswordRequestSchema
+>;
+
+export type PostUpdateUserPasswordResponse = PostUserResponse;
+
+export const GetUserBySerialRequestSchema = z.object({
+  searchTerm: z.string(),
+});
+
+export type GetUserBySerialRequest = z.infer<
+  typeof GetUserBySerialRequestSchema
+>;
+
 export interface GetUserBySerialResponse {
   message: string;
   serial: string;
@@ -34,8 +61,12 @@ export interface GetUserBySerialResponse {
   username: string;
 }
 
-export interface UserGames {
-  enteredGames: readonly SelectedGame[];
-  favoritedGames: readonly Game[];
-  signedGames: readonly SelectedGame[];
+export interface GetSignupMessagesResponse {
+  signupMessages: SignupMessage[];
+  message: string;
+  status: "success";
+}
+
+export interface GetSignupMessagesError extends ApiError {
+  errorId: "unknown";
 }

--- a/shared/typings/models/feedback.ts
+++ b/shared/typings/models/feedback.ts
@@ -1,9 +1,5 @@
-import { z } from "zod";
-
-export const FeedbackSchema = z.object({
-  gameId: z.string(),
-  feedback: z.string(),
-  username: z.string(),
-});
-
-export type Feedback = z.infer<typeof FeedbackSchema>;
+export interface Feedback {
+  gameId: string;
+  feedback: string;
+  username: string;
+}

--- a/shared/typings/models/game.ts
+++ b/shared/typings/models/game.ts
@@ -97,3 +97,13 @@ export const GameSchema = z.object({
 });
 
 export type Game = z.infer<typeof GameSchema>;
+
+export interface GameWithUsernames {
+  game: Game;
+  users: UserSignup[];
+}
+
+export interface UserSignup {
+  username: string;
+  signupMessage: string;
+}

--- a/shared/typings/models/groups.ts
+++ b/shared/typings/models/groups.ts
@@ -1,0 +1,8 @@
+import { SelectedGame } from "shared/typings/models/user";
+
+export interface GroupMember {
+  groupCode: string;
+  serial: string;
+  signedGames: readonly SelectedGame[];
+  username: string;
+}

--- a/shared/typings/models/signupMessage.ts
+++ b/shared/typings/models/signupMessage.ts
@@ -1,18 +1,6 @@
-import { ApiError } from "shared/typings/api/errors";
-
 export interface SignupMessage {
   gameId: string;
   username: string;
   message: string;
   private: boolean;
-}
-
-export interface GetSignupMessagesResponse {
-  signupMessages: SignupMessage[];
-  message: string;
-  status: "success";
-}
-
-export interface GetSignupMessagesError extends ApiError {
-  errorId: "unknown";
 }

--- a/shared/typings/models/user.ts
+++ b/shared/typings/models/user.ts
@@ -23,3 +23,9 @@ export enum UserGroup {
   ADMIN = "admin",
   HELP = "help",
 }
+
+export interface UserGames {
+  enteredGames: readonly SelectedGame[];
+  favoritedGames: readonly Game[];
+  signedGames: readonly SelectedGame[];
+}


### PR DESCRIPTION
* Lisätään clientin päähän kaikille API-kutsuille request-tyyppi
  * Tehdään clientin API-kutsujen request-tyyppi pakolliseksi
* Bäkkärillä useat näistä requesteista oli jo tyypitetty `zod` avulla -> siirretään nämä omaan paikkaan ja nimetään konsistentisti `PostFooRequest` jne
