### PR TITLE
Get API request user from JWT

### DIFF
--- a/client/src/services/feedbackServices.test.ts
+++ b/client/src/services/feedbackServices.test.ts
@@ -10,15 +10,13 @@ test("POST feedback to server", async () => {
 
   const feedback = "test feedback";
   const gameId = "123";
-  const username = "test user";
 
-  const response = await postFeedback({ feedback, gameId, username });
+  const response = await postFeedback(gameId, feedback);
 
   expect(response).toEqual("test response");
   expect(spy).toHaveBeenCalledTimes(1);
   expect(spy).toHaveBeenCalledWith(ApiEndpoint.FEEDBACK, {
     feedback,
     gameId,
-    username,
   });
 });

--- a/client/src/services/feedbackServices.ts
+++ b/client/src/services/feedbackServices.ts
@@ -5,17 +5,16 @@ import {
   PostFeedbackRequest,
   PostFeedbackResponse,
 } from "shared/typings/api/feedback";
-import { Feedback } from "shared/typings/models/feedback";
 
 export const postFeedback = async (
-  feedbackData: Feedback
+  gameId: string,
+  feedback: string
 ): Promise<PostFeedbackResponse | ApiError> => {
   const response = await api.post<PostFeedbackResponse, PostFeedbackRequest>(
     ApiEndpoint.FEEDBACK,
     {
-      feedback: feedbackData.feedback,
-      gameId: feedbackData.gameId,
-      username: feedbackData.username,
+      gameId,
+      feedback,
     }
   );
 

--- a/client/src/services/groupServices.test.ts
+++ b/client/src/services/groupServices.test.ts
@@ -8,14 +8,13 @@ test("GET group from server", async () => {
   const spy = vi.spyOn(api, "get").mockResolvedValue({ data: "test response" });
 
   const groupCode = "123";
-  const username = "test user";
 
-  const response = await getGroup(groupCode, username);
+  const response = await getGroup(groupCode);
 
   expect(response).toEqual("test response");
   expect(spy).toHaveBeenCalledTimes(1);
   expect(spy).toHaveBeenCalledWith(ApiEndpoint.GROUP, {
-    params: { groupCode, username },
+    params: { groupCode },
   });
 });
 
@@ -26,7 +25,6 @@ test("POST group to server", async () => {
 
   const groupRequest: PostCreateGroupRequest = {
     groupCode: "123",
-    username: "test user",
   };
 
   const response = await postCreateGroup(groupRequest);

--- a/client/src/services/groupServices.ts
+++ b/client/src/services/groupServices.ts
@@ -6,7 +6,6 @@ import {
   PostCreateGroupRequest,
   PostCreateGroupError,
   PostJoinGroupRequest,
-  PostLeaveGroupRequest,
   PostCloseGroupRequest,
   PostJoinGroupError,
   PostLeaveGroupError,
@@ -38,13 +37,12 @@ export const postJoinGroup = async (
   return response.data;
 };
 
-export const postLeaveGroup = async (
-  groupRequest: PostLeaveGroupRequest
-): Promise<PostLeaveGroupResponse | PostLeaveGroupError> => {
-  const response = await api.post<
-    PostLeaveGroupResponse,
-    PostLeaveGroupRequest
-  >(ApiEndpoint.LEAVE_GROUP, groupRequest);
+export const postLeaveGroup = async (): Promise<
+  PostLeaveGroupResponse | PostLeaveGroupError
+> => {
+  const response = await api.post<PostLeaveGroupResponse, {}>(
+    ApiEndpoint.LEAVE_GROUP
+  );
   return response.data;
 };
 
@@ -53,21 +51,19 @@ export const postCloseGroup = async (
 ): Promise<PostCloseGroupResponse | PostCloseGroupError> => {
   const response = await api.post<
     PostCloseGroupResponse,
-    PostLeaveGroupRequest
+    PostCloseGroupRequest
   >(ApiEndpoint.CLOSE_GROUP, groupRequest);
   return response.data;
 };
 
 export const getGroup = async (
-  groupCode: string,
-  username: string
+  groupCode: string
 ): Promise<GetGroupResponse | GetGroupError> => {
   const response = await api.get<GetGroupResponse, GetGroupRequest>(
     ApiEndpoint.GROUP,
     {
       params: {
         groupCode,
-        username,
       },
     }
   );

--- a/client/src/services/userServices.test.ts
+++ b/client/src/services/userServices.test.ts
@@ -68,17 +68,15 @@ test("POST new user password to server", async () => {
     .spyOn(api, "post")
     .mockResolvedValue({ data: "test response" });
 
-  const username = "test username";
+  const userToUpdateUsername = "test username";
   const password = "test password";
-  const requester = "test requester";
 
-  const response = await updateUserPassword(username, password, requester);
+  const response = await updateUserPassword(userToUpdateUsername, password);
 
   expect(response).toEqual("test response");
   expect(spy).toHaveBeenCalledTimes(1);
   expect(spy).toHaveBeenCalledWith(ApiEndpoint.USERS_PASSWORD, {
-    username,
+    userToUpdateUsername,
     password,
-    requester,
   });
 });

--- a/client/src/services/userServices.ts
+++ b/client/src/services/userServices.ts
@@ -6,7 +6,6 @@ import {
   GetSignupMessagesResponse,
   GetUserBySerialRequest,
   GetUserBySerialResponse,
-  GetUserRequest,
   GetUserResponse,
   PostUpdateUserPasswordRequest,
   PostUpdateUserPasswordResponse,
@@ -35,14 +34,11 @@ export const postRegistration = async (
 export const getUser = async (
   username: string
 ): Promise<GetUserResponse | ApiError> => {
-  const response = await api.get<GetUserResponse, GetUserRequest>(
-    ApiEndpoint.USERS,
-    {
-      params: {
-        username,
-      },
-    }
-  );
+  const response = await api.get<GetUserResponse, {}>(ApiEndpoint.USERS, {
+    params: {
+      username,
+    },
+  });
   return response.data;
 };
 
@@ -61,17 +57,15 @@ export const getUserBySerialOrUsername = async (
 };
 
 export const updateUserPassword = async (
-  username: string,
-  password: string,
-  requester: string
+  userToUpdateUsername: string,
+  password: string
 ): Promise<PostUpdateUserPasswordResponse | ApiError> => {
   const response = await api.post<
     PostUpdateUserPasswordResponse,
     PostUpdateUserPasswordRequest
   >(ApiEndpoint.USERS_PASSWORD, {
-    username,
+    userToUpdateUsername,
     password,
-    requester,
   });
   return response.data;
 };

--- a/client/src/utils/loadData.ts
+++ b/client/src/utils/loadData.ts
@@ -74,11 +74,11 @@ export const loadUser = async (): Promise<void> => {
 export const loadGroupMembers = async (): Promise<void> => {
   const state = store.getState();
   const dispatch: AppDispatch = store.dispatch;
-  const { loggedIn, username } = state.login;
+  const { loggedIn } = state.login;
   const { groupCode } = state.group;
 
   if (loggedIn && groupCode !== "0") {
-    await dispatch(submitGetGroup(groupCode, username));
+    await dispatch(submitGetGroup(groupCode));
   }
 };
 

--- a/client/src/views/all-games/components/AlgorithmSignupForm.tsx
+++ b/client/src/views/all-games/components/AlgorithmSignupForm.tsx
@@ -41,7 +41,6 @@ export const AlgorithmSignupForm = ({
   const dispatch = useAppDispatch();
   const { signupOpen, manualSignupMode } = sharedConfig;
 
-  const username = useAppSelector((state) => state.login.username);
   const loggedIn = useAppSelector((state) => state.login.loggedIn);
   const serial = useAppSelector((state) => state.login.serial);
   const groupCode = useAppSelector((state) => state.group.groupCode);
@@ -61,7 +60,6 @@ export const AlgorithmSignupForm = ({
 
     const error = await dispatch(
       submitPostSignedGames({
-        username,
         selectedGames: newSignupData,
         startTime: gameToRemove.startTime,
       })

--- a/client/src/views/all-games/components/EnterGameForm.tsx
+++ b/client/src/views/all-games/components/EnterGameForm.tsx
@@ -69,13 +69,7 @@ export const EnterGameForm = (props: Props): ReactElement => {
       !directSignupAlwaysOpenIds.includes(game.gameId)
     ) {
       if (isInGroup && !isGroupCreator) {
-        const leaveGroupRequest = {
-          username,
-        };
-
-        const leaveGroupError = await dispatch(
-          submitLeaveGroup(leaveGroupRequest)
-        );
+        const leaveGroupError = await dispatch(submitLeaveGroup());
 
         if (leaveGroupError) {
           setErrorMessage(leaveGroupError);

--- a/client/src/views/all-games/components/FeedbackForm.tsx
+++ b/client/src/views/all-games/components/FeedbackForm.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import { postFeedback } from "client/services/feedbackServices";
 import { Game } from "shared/typings/models/game";
 import { Button, ButtonStyle } from "client/components/Button";
-import { useAppSelector } from "client/utils/hooks";
 import { TextArea } from "client/components/TextArea";
 
 interface Props {
@@ -12,8 +11,6 @@ interface Props {
 }
 
 export const FeedbackForm = ({ game }: Props): ReactElement => {
-  const username = useAppSelector((state) => state.login.username);
-
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [feedbackValue, setFeedbackValue] = useState<string>("");
   const [feedbackSent, setFeedbackSent] = useState<boolean>(false);
@@ -24,14 +21,8 @@ export const FeedbackForm = ({ game }: Props): ReactElement => {
   const sendFeedbackEvent = async (): Promise<void> => {
     setSubmitting(true);
 
-    const feedbackData = {
-      gameId: game.gameId,
-      feedback: feedbackValue,
-      username,
-    };
-
     try {
-      await postFeedback(feedbackData);
+      await postFeedback(game.gameId, feedbackValue);
     } catch (error) {
       console.log(`postFeedback error:`, error); // eslint-disable-line no-console
     }

--- a/client/src/views/all-games/components/SignupForm.tsx
+++ b/client/src/views/all-games/components/SignupForm.tsx
@@ -29,7 +29,6 @@ export const SignupForm = ({
   const dispatch = useAppDispatch();
   // We need all signed games here
   const signedGames = useAppSelector((state) => state.myGames.signedGames);
-  const username = useAppSelector((state) => state.login.username);
 
   const selectedPriorities = signedGames
     .filter((signedGame) => signedGame.gameDetails.startTime === startTime)
@@ -71,7 +70,6 @@ export const SignupForm = ({
 
     const error = await dispatch(
       submitPostSignedGames({
-        username,
         selectedGames: signedGames.concat(newGame),
         startTime: game.startTime,
       })

--- a/client/src/views/group/GroupView.tsx
+++ b/client/src/views/group/GroupView.tsx
@@ -110,7 +110,7 @@ export const GroupView = (): ReactElement => {
                     <BoldText>{t("group.youAreInGroup")}</BoldText>.{" "}
                     {t("group.groupMemberInfo")}
                   </p>
-                  <GroupMemberActions username={username} />
+                  <GroupMemberActions />
                 </>
               )}
 

--- a/client/src/views/group/components/GroupCreatorActions.tsx
+++ b/client/src/views/group/components/GroupCreatorActions.tsx
@@ -14,10 +14,7 @@ interface Props {
   groupCode: string;
 }
 
-export const GroupCreatorActions = ({
-  username,
-  groupCode,
-}: Props): ReactElement => {
+export const GroupCreatorActions = ({ groupCode }: Props): ReactElement => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
@@ -32,7 +29,6 @@ export const GroupCreatorActions = ({
 
     const errorMessage = await dispatch(
       submitCloseGroup({
-        username,
         groupCode,
       })
     );

--- a/client/src/views/group/components/GroupMemberActions.tsx
+++ b/client/src/views/group/components/GroupMemberActions.tsx
@@ -8,11 +8,7 @@ import {
 } from "client/views/group/groupThunks";
 import { ErrorMessage } from "client/components/ErrorMessage";
 
-interface Props {
-  username: string;
-}
-
-export const GroupMemberActions = ({ username }: Props): ReactElement => {
+export const GroupMemberActions = (): ReactElement => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation();
 
@@ -23,11 +19,7 @@ export const GroupMemberActions = ({ username }: Props): ReactElement => {
   const leaveGroup = async (): Promise<void> => {
     setLoading(true);
 
-    const errorMessage = await dispatch(
-      submitLeaveGroup({
-        username,
-      })
-    );
+    const errorMessage = await dispatch(submitLeaveGroup());
 
     if (errorMessage) {
       setServerError(errorMessage);

--- a/client/src/views/group/components/NotInGroupActions.tsx
+++ b/client/src/views/group/components/NotInGroupActions.tsx
@@ -20,7 +20,6 @@ interface Props {
 }
 
 export const NotInGroupActions = ({
-  username,
   serial,
   disabled,
 }: Props): ReactElement => {
@@ -52,7 +51,6 @@ export const NotInGroupActions = ({
 
     const errorMessage = await dispatch(
       submitCreateGroup({
-        username,
         groupCode: serial,
       })
     );
@@ -72,7 +70,6 @@ export const NotInGroupActions = ({
 
     const errorMessage = await dispatch(
       submitJoinGroup({
-        username,
         groupCode: joinGroupValue,
         ownSerial: serial,
       })

--- a/client/src/views/group/groupThunks.ts
+++ b/client/src/views/group/groupThunks.ts
@@ -15,7 +15,6 @@ import {
   PostCloseGroupRequest,
   PostCreateGroupRequest,
   PostJoinGroupRequest,
-  PostLeaveGroupRequest,
 } from "shared/typings/api/groups";
 import { exhaustiveSwitchGuard } from "shared/utils/exhaustiveSwitchGuard";
 
@@ -45,7 +44,7 @@ export const submitCreateGroup = (
     }
 
     if (createGroupResponse?.status === "success") {
-      dispatch(submitGetGroup(createGroupResponse.groupCode, group.username));
+      dispatch(submitGetGroup(createGroupResponse.groupCode));
       dispatch(submitUpdateGroupCodeAsync(createGroupResponse.groupCode));
     }
   };
@@ -86,9 +85,7 @@ export const submitJoinGroup = (
     }
 
     if (joinGroupResponse?.status === "success") {
-      dispatch(
-        submitGetGroup(joinGroupResponse.groupCode, groupRequest.username)
-      );
+      dispatch(submitGetGroup(joinGroupResponse.groupCode));
       dispatch(submitUpdateGroupCodeAsync(joinGroupResponse.groupCode));
     }
   };
@@ -99,11 +96,11 @@ export enum PostLeaveGroupErrorMessage {
   FAILED_TO_LEAVE = "group.generalLeaveGroupError",
 }
 
-export const submitLeaveGroup = (
-  groupRequest: PostLeaveGroupRequest
-): AppThunk<Promise<PostLeaveGroupErrorMessage | undefined>> => {
+export const submitLeaveGroup = (): AppThunk<
+  Promise<PostLeaveGroupErrorMessage | undefined>
+> => {
   return async (dispatch): Promise<PostLeaveGroupErrorMessage | undefined> => {
-    const leaveGroupResponse = await postLeaveGroup(groupRequest);
+    const leaveGroupResponse = await postLeaveGroup();
 
     if (leaveGroupResponse?.status === "error") {
       switch (leaveGroupResponse.errorId) {
@@ -155,11 +152,10 @@ enum GetGroupErrorMessage {
 }
 
 export const submitGetGroup = (
-  groupCode: string,
-  username: string
+  groupCode: string
 ): AppThunk<Promise<GetGroupErrorMessage | undefined>> => {
   return async (dispatch): Promise<GetGroupErrorMessage | undefined> => {
-    const getGroupResponse = await getGroup(groupCode, username);
+    const getGroupResponse = await getGroup(groupCode);
 
     if (getGroupResponse?.status === "error") {
       switch (getGroupResponse.errorId) {

--- a/client/src/views/helper/components/ChangePasswordForm.tsx
+++ b/client/src/views/helper/components/ChangePasswordForm.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import { Button, ButtonStyle } from "client/components/Button";
 import { updateUserPassword } from "client/services/userServices";
 import { passwordLength } from "client/utils/validate";
-import { useAppSelector } from "client/utils/hooks";
 import { ControlledInput } from "client/components/ControlledInput";
 
 interface Props {
@@ -14,8 +13,6 @@ interface Props {
 
 export const ChangePasswordForm = ({ username }: Props): ReactElement => {
   const { t } = useTranslation();
-
-  const requester = useAppSelector((state) => state.login.username);
 
   const [changePasswordInput, setChangePasswordInput] = useState<string>("");
   const [passwordChangeMessage, setPasswordChangeMessage] =
@@ -37,11 +34,7 @@ export const ChangePasswordForm = ({ username }: Props): ReactElement => {
       return;
     }
 
-    const response = await updateUserPassword(
-      username,
-      changePasswordInput,
-      requester
-    );
+    const response = await updateUserPassword(username, changePasswordInput);
 
     if (!response || response.status === "error") {
       setPasswordChangeMessage(

--- a/client/src/views/my-games/myGamesThunks.ts
+++ b/client/src/views/my-games/myGamesThunks.ts
@@ -1,7 +1,6 @@
 import { getUser } from "client/services/userServices";
 import { postFavorite } from "client/services/favoriteServices";
 import { AppThunk } from "client/typings/redux.typings";
-import { PostFavoriteRequest } from "shared/typings/api/favorite";
 import {
   submitDeleteEnteredAsync,
   submitPostEnteredGameAsync,
@@ -20,6 +19,7 @@ import {
   postSignedGames,
 } from "client/services/myGamesServices";
 import { exhaustiveSwitchGuard } from "shared/utils/exhaustiveSwitchGuard";
+import { NewFavorite } from "shared/typings/models/user";
 
 export const submitGetUser = (username: string): AppThunk => {
   return async (dispatch): Promise<void> => {
@@ -45,9 +45,7 @@ export const submitGetUser = (username: string): AppThunk => {
   };
 };
 
-export const submitUpdateFavorites = (
-  favoriteData: PostFavoriteRequest
-): AppThunk => {
+export const submitUpdateFavorites = (favoriteData: NewFavorite): AppThunk => {
   return async (dispatch): Promise<void> => {
     const updateFavoriteResponse = await postFavorite(favoriteData);
 

--- a/server/src/features/feedback/feedbackController.test.ts
+++ b/server/src/features/feedback/feedbackController.test.ts
@@ -12,6 +12,8 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 import { faker } from "@faker-js/faker";
 import { startServer, closeServer } from "server/utils/server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
+import { getJWT } from "server/utils/jwt";
+import { UserGroup } from "shared/typings/models/user";
 
 let server: Server;
 let mongoServer: MongoMemoryServer;
@@ -36,16 +38,14 @@ afterAll(async () => {
   await mongoServer.stop();
 });
 
-test(`POST ${ApiEndpoint.FEEDBACK} should return 422 without valid body`, async () => {
-  const response = await request(server).post(ApiEndpoint.FEEDBACK);
-  expect(response.status).toEqual(422);
+test(`POST ${ApiEndpoint.FEEDBACK} should return 401 without valid authorization`, async () => {
+  const response = await request(server).post(ApiEndpoint.FEEDBACK).send();
+  expect(response.status).toEqual(401);
 });
 
-test(`POST ${ApiEndpoint.FEEDBACK} should return 401 without valid authorization`, async () => {
-  const response = await request(server).post(ApiEndpoint.FEEDBACK).send({
-    gameId: "1234",
-    feedback: "test feedback",
-    username: "testuser",
-  });
-  expect(response.status).toEqual(401);
+test(`POST ${ApiEndpoint.FEEDBACK} should return 422 without valid body`, async () => {
+  const response = await request(server)
+    .post(ApiEndpoint.FEEDBACK)
+    .set("Authorization", `Bearer ${getJWT(UserGroup.USER, "testuser")}`);
+  expect(response.status).toEqual(422);
 });

--- a/server/src/features/feedback/feedbackController.ts
+++ b/server/src/features/feedback/feedbackController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { ZodError } from "zod";
 import { isAuthorized } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import { storeFeedback } from "server/features/feedback/feedbackService";
@@ -20,16 +21,19 @@ export const postFeedback = async (
     return res.sendStatus(401);
   }
 
-  let parameters;
+  let body;
   try {
-    parameters = PostFeedbackRequestSchema.parse(req.body);
+    body = PostFeedbackRequestSchema.parse(req.body);
   } catch (error) {
+    if (error instanceof ZodError) {
+      logger.error(`Error validating postFeedback body: ${error.message}`);
+    }
     return res.sendStatus(422);
   }
 
   const response = await storeFeedback({
-    gameId: parameters.gameId,
-    feedback: parameters.feedback,
+    gameId: body.gameId,
+    feedback: body.feedback,
     username,
   });
   return res.json(response);

--- a/server/src/features/feedback/feedbackController.ts
+++ b/server/src/features/feedback/feedbackController.ts
@@ -15,6 +15,11 @@ export const postFeedback = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.FEEDBACK}`);
 
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
+    return res.sendStatus(401);
+  }
+
   let parameters;
   try {
     parameters = PostFeedbackRequestSchema.parse(req.body);
@@ -22,16 +27,10 @@ export const postFeedback = async (
     return res.sendStatus(422);
   }
 
-  if (
-    !isAuthorized(
-      req.headers.authorization,
-      UserGroup.USER,
-      parameters.username
-    )
-  ) {
-    return res.sendStatus(401);
-  }
-
-  const response = await storeFeedback(parameters);
+  const response = await storeFeedback({
+    gameId: parameters.gameId,
+    feedback: parameters.feedback,
+    username,
+  });
   return res.json(response);
 };

--- a/server/src/features/feedback/feedbackController.ts
+++ b/server/src/features/feedback/feedbackController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { ZodError } from "zod";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import { storeFeedback } from "server/features/feedback/feedbackService";
 import { logger } from "server/utils/logger";
@@ -16,7 +16,10 @@ export const postFeedback = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.FEEDBACK}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/game/gameController.ts
+++ b/server/src/features/game/gameController.ts
@@ -11,7 +11,8 @@ export const postUpdateGames = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.GAMES}`);
 
-  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN, "admin")) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  if (!username) {
     return res.sendStatus(401);
   }
 

--- a/server/src/features/game/gameController.ts
+++ b/server/src/features/game/gameController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import { fetchGames, updateGames } from "server/features/game/gamesService";
 import { logger } from "server/utils/logger";
@@ -11,7 +11,10 @@ export const postUpdateGames = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.GAMES}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.ADMIN
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/results/resultsController.ts
+++ b/server/src/features/results/resultsController.ts
@@ -43,7 +43,8 @@ export const postAssignment = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.ASSIGNMENT}`);
 
-  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN, "admin")) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  if (!username) {
     return res.sendStatus(401);
   }
 

--- a/server/src/features/results/resultsController.ts
+++ b/server/src/features/results/resultsController.ts
@@ -3,7 +3,7 @@ import { ZodError } from "zod";
 import { storeAssignment } from "server/features/player-assignment/assignmentController";
 import { fetchResults } from "server/features/results/resultsService";
 import { UserGroup } from "shared/typings/models/user";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
@@ -47,7 +47,10 @@ export const postAssignment = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.ASSIGNMENT}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.ADMIN
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/results/resultsController.ts
+++ b/server/src/features/results/resultsController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { ZodError } from "zod";
 import { storeAssignment } from "server/features/player-assignment/assignmentController";
 import { fetchResults } from "server/features/results/resultsService";
 import { UserGroup } from "shared/typings/models/user";
@@ -20,14 +21,17 @@ export const getResults = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.RESULTS}`);
 
-  let parameters;
+  let body;
   try {
-    parameters = GetResultsRequestSchema.parse(req.query);
+    body = GetResultsRequestSchema.parse(req.query);
   } catch (error) {
+    if (error instanceof ZodError) {
+      logger.error(`Error validating getResults body: ${error.message}`);
+    }
     return res.sendStatus(422);
   }
 
-  const { startTime } = parameters;
+  const { startTime } = body;
 
   if (!startTime) {
     return res.sendStatus(422);

--- a/server/src/features/sentry-tunnel/sentryTunnelController.ts
+++ b/server/src/features/sentry-tunnel/sentryTunnelController.ts
@@ -22,7 +22,8 @@ export const getSentryTest = (
 ): Response => {
   logger.info(`API call: POST ${ApiEndpoint.SENTRY_TEST}`);
 
-  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN, "admin")) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  if (!username) {
     return res.sendStatus(401);
   }
 

--- a/server/src/features/sentry-tunnel/sentryTunnelController.ts
+++ b/server/src/features/sentry-tunnel/sentryTunnelController.ts
@@ -3,7 +3,7 @@ import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { resendSentryRequest } from "server/features/sentry-tunnel/sentryTunnelService";
 import { UserGroup } from "shared/typings/models/user";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 
 export const postSentryTunnel = async (
   req: Request<{}, {}, null>,
@@ -22,7 +22,10 @@ export const getSentryTest = (
 ): Response => {
   logger.info(`API call: POST ${ApiEndpoint.SENTRY_TEST}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.ADMIN
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/settings/settingsController.ts
+++ b/server/src/features/settings/settingsController.ts
@@ -25,7 +25,8 @@ export const postHidden = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.HIDDEN}`);
 
-  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN, "admin")) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  if (!username) {
     return res.sendStatus(401);
   }
 
@@ -50,7 +51,8 @@ export const postSignupQuestion = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNUP_QUESTION}`);
 
-  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN, "admin")) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  if (!username) {
     return res.sendStatus(401);
   }
 
@@ -64,7 +66,8 @@ export const deleteSignupQuestion = async (
 ): Promise<Response> => {
   logger.info(`API call: DELETE ${ApiEndpoint.SIGNUP_QUESTION}`);
 
-  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN, "admin")) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  if (!username) {
     return res.sendStatus(401);
   }
 
@@ -78,7 +81,8 @@ export const postSettings = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SETTINGS}`);
 
-  if (!isAuthorized(req.headers.authorization, UserGroup.ADMIN, "admin")) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  if (!username) {
     return res.sendStatus(401);
   }
 

--- a/server/src/features/settings/settingsController.ts
+++ b/server/src/features/settings/settingsController.ts
@@ -8,7 +8,7 @@ import {
   updateSettings,
 } from "server/features/settings/settingsService";
 import { UserGroup } from "shared/typings/models/user";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
@@ -25,7 +25,10 @@ export const postHidden = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.HIDDEN}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.ADMIN
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -51,7 +54,10 @@ export const postSignupQuestion = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNUP_QUESTION}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.ADMIN
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -66,7 +72,10 @@ export const deleteSignupQuestion = async (
 ): Promise<Response> => {
   logger.info(`API call: DELETE ${ApiEndpoint.SIGNUP_QUESTION}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.ADMIN
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -81,7 +90,10 @@ export const postSettings = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SETTINGS}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.ADMIN);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.ADMIN
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/settings/settingsController.ts
+++ b/server/src/features/settings/settingsController.ts
@@ -86,18 +86,16 @@ export const postSettings = async (
     return res.sendStatus(401);
   }
 
-  let settings;
+  let body;
   try {
-    settings = PostSettingsRequestSchema.parse(req.body);
+    body = PostSettingsRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postSettings parameters: ${error.message}`
-      );
+      logger.error(`Error validating postSettings body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const response = await updateSettings(settings);
+  const response = await updateSettings(body);
   return res.json(response);
 };

--- a/server/src/features/signup/signupController.ts
+++ b/server/src/features/signup/signupController.ts
@@ -26,16 +26,17 @@ export const postSignup = async (
     return res.sendStatus(401);
   }
 
+  let body;
   try {
-    PostEnteredGameRequestSchema.parse(req.body);
+    body = PostEnteredGameRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.info(`Error validating postSignup parameters: ${error.message}`);
+      logger.info(`Error validating postSignup body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const response = await storeSignup(req.body);
+  const response = await storeSignup(body);
   return res.json(response);
 };
 
@@ -50,17 +51,16 @@ export const deleteSignup = async (
     return res.sendStatus(401);
   }
 
+  let body;
   try {
-    DeleteEnteredGameRequestSchema.parse(req.body);
+    body = DeleteEnteredGameRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating deleteSignup parameters: ${error.message}`
-      );
+      logger.error(`Error validating deleteSignup body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const response = await removeSignup(req.body);
+  const response = await removeSignup(body);
   return res.json(response);
 };

--- a/server/src/features/signup/signupController.ts
+++ b/server/src/features/signup/signupController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { ZodError } from "zod";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import {
@@ -21,7 +21,10 @@ export const postSignup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNUP}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -46,7 +49,10 @@ export const deleteSignup = async (
 ): Promise<Response> => {
   logger.info(`API call: DELETE ${ApiEndpoint.SIGNUP}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/signup/signupController.ts
+++ b/server/src/features/signup/signupController.ts
@@ -21,9 +21,8 @@ export const postSignup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNUP}`);
 
-  const { username } = req.body;
-
-  if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
     return res.sendStatus(401);
   }
 
@@ -46,9 +45,8 @@ export const deleteSignup = async (
 ): Promise<Response> => {
   logger.info(`API call: DELETE ${ApiEndpoint.SIGNUP}`);
 
-  const { username } = req.body;
-
-  if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
     return res.sendStatus(401);
   }
 

--- a/server/src/features/user/favorite-game/favoriteGameController.test.ts
+++ b/server/src/features/user/favorite-game/favoriteGameController.test.ts
@@ -11,7 +11,8 @@ import request from "supertest";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { startTestServer, stopTestServer } from "server/test/utils/testServer";
-import { PostFavoriteRequest } from "shared/typings/api/favorite";
+import { UserGroup } from "shared/typings/models/user";
+import { getJWT } from "server/utils/jwt";
 
 let mongoServer: MongoMemoryServer;
 
@@ -28,30 +29,25 @@ afterAll(async () => {
 });
 
 describe(`POST ${ApiEndpoint.FAVORITE}`, () => {
-  test("should return 422 without valid body", async () => {
+  test("should return 401 without valid authorization", async () => {
     const { server } = await startTestServer(mongoServer.getUri());
 
     try {
       const response = await request(server).post(ApiEndpoint.FAVORITE);
-      expect(response.status).toEqual(422);
+      expect(response.status).toEqual(401);
     } finally {
       await stopTestServer(server);
     }
   });
 
-  test("should return 401 without valid authorization", async () => {
+  test("should return 422 without valid body", async () => {
     const { server } = await startTestServer(mongoServer.getUri());
-
-    const saveFavoriteRequest: PostFavoriteRequest = {
-      username: "testuser",
-      favoritedGameIds: [],
-    };
 
     try {
       const response = await request(server)
         .post(ApiEndpoint.FAVORITE)
-        .send(saveFavoriteRequest);
-      expect(response.status).toEqual(401);
+        .set("Authorization", `Bearer ${getJWT(UserGroup.USER, "testuser")}`);
+      expect(response.status).toEqual(422);
     } finally {
       await stopTestServer(server);
     }

--- a/server/src/features/user/favorite-game/favoriteGameController.ts
+++ b/server/src/features/user/favorite-game/favoriteGameController.ts
@@ -21,21 +21,19 @@ export const postFavorite = async (
     return res.sendStatus(401);
   }
 
-  let parameters;
+  let body;
   try {
-    parameters = PostFavoriteRequestSchema.parse(req.body);
+    body = PostFavoriteRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postFavorite parameters: ${error.message}`
-      );
+      logger.error(`Error validating postFavorite body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
   const response = await storeFavorite({
     username,
-    favoritedGameIds: parameters.favoritedGameIds,
+    favoritedGameIds: body.favoritedGameIds,
   });
   return res.json(response);
 };

--- a/server/src/features/user/favorite-game/favoriteGameController.ts
+++ b/server/src/features/user/favorite-game/favoriteGameController.ts
@@ -6,7 +6,7 @@ import {
   PostFavoriteRequest,
   PostFavoriteRequestSchema,
 } from "shared/typings/api/favorite";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import { storeFavorite } from "server/features/user/favorite-game/favoriteGameService";
 
@@ -16,7 +16,10 @@ export const postFavorite = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.FAVORITE}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/user/favorite-game/favoriteGameController.ts
+++ b/server/src/features/user/favorite-game/favoriteGameController.ts
@@ -16,6 +16,11 @@ export const postFavorite = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.FAVORITE}`);
 
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
+    return res.sendStatus(401);
+  }
+
   let parameters;
   try {
     parameters = PostFavoriteRequestSchema.parse(req.body);
@@ -28,18 +33,9 @@ export const postFavorite = async (
     return res.sendStatus(422);
   }
 
-  const favoriteData = parameters;
-
-  if (
-    !isAuthorized(
-      req.headers.authorization,
-      UserGroup.USER,
-      favoriteData.username
-    )
-  ) {
-    return res.sendStatus(401);
-  }
-
-  const response = await storeFavorite(favoriteData);
+  const response = await storeFavorite({
+    username,
+    favoritedGameIds: parameters.favoritedGameIds,
+  });
   return res.json(response);
 };

--- a/server/src/features/user/favorite-game/favoriteGameRepository.ts
+++ b/server/src/features/user/favorite-game/favoriteGameRepository.ts
@@ -1,12 +1,11 @@
 import { findGames } from "server/features/game/gameRepository";
 import { UserModel } from "server/features/user/userSchema";
 import { logger } from "server/utils/logger";
-import { PostFavoriteRequest } from "shared/typings/api/favorite";
 import { Game } from "shared/typings/models/game";
-import { User } from "shared/typings/models/user";
+import { NewFavorite, User } from "shared/typings/models/user";
 
 export const saveFavorite = async (
-  favoriteData: PostFavoriteRequest
+  favoriteData: NewFavorite
 ): Promise<readonly Game[] | null> => {
   const { username, favoritedGameIds } = favoriteData;
 

--- a/server/src/features/user/favorite-game/favoriteGameService.ts
+++ b/server/src/features/user/favorite-game/favoriteGameService.ts
@@ -1,12 +1,10 @@
 import { saveFavorite } from "server/features/user/favorite-game/favoriteGameRepository";
 import { ApiError } from "shared/typings/api/errors";
-import {
-  PostFavoriteResponse,
-  PostFavoriteRequest,
-} from "shared/typings/api/favorite";
+import { PostFavoriteResponse } from "shared/typings/api/favorite";
+import { NewFavorite } from "shared/typings/models/user";
 
 export const storeFavorite = async (
-  favoriteData: PostFavoriteRequest
+  favoriteData: NewFavorite
 ): Promise<PostFavoriteResponse | ApiError> => {
   let favoritedGames;
   try {

--- a/server/src/features/user/group/groupController.test.ts
+++ b/server/src/features/user/group/groupController.test.ts
@@ -17,7 +17,6 @@ import {
   PostCloseGroupRequest,
   PostCreateGroupRequest,
   PostJoinGroupRequest,
-  PostLeaveGroupRequest,
 } from "shared/typings/api/groups";
 import { UserGroup } from "shared/typings/models/user";
 import { getJWT } from "server/utils/jwt";
@@ -59,17 +58,19 @@ afterAll(async () => {
 });
 
 describe(`GET ${ApiEndpoint.GROUP}`, () => {
-  test("should return 422 without valid body", async () => {
+  test("should return 401 without valid authorization", async () => {
     const response = await request(server).get(ApiEndpoint.GROUP);
-    expect(response.status).toEqual(422);
+    expect(response.status).toEqual(401);
   });
 
-  test("should return 401 without valid authorization", async () => {
-    const response = await request(server).get(ApiEndpoint.GROUP).query({
-      username: "testuser",
-      groupCode: "1234",
-    });
-    expect(response.status).toEqual(401);
+  test("should return 422 without valid body", async () => {
+    const response = await request(server)
+      .get(ApiEndpoint.GROUP)
+      .set(
+        "Authorization",
+        `Bearer ${getJWT(UserGroup.USER, mockUser2.username)}`
+      );
+    expect(response.status).toEqual(422);
   });
 
   test("should return group members", async () => {
@@ -99,21 +100,16 @@ describe(`GET ${ApiEndpoint.GROUP}`, () => {
 });
 
 describe(`POST ${ApiEndpoint.GROUP}`, () => {
-  test("should return 422 without valid body", async () => {
+  test("should return 401 without valid authorization", async () => {
     const response = await request(server).post(ApiEndpoint.GROUP);
-    expect(response.status).toEqual(422);
+    expect(response.status).toEqual(401);
   });
 
-  test("should return 401 without valid authorization", async () => {
-    const groupRequest: PostCreateGroupRequest = {
-      groupCode: "1234",
-      username: "testuser",
-    };
-
+  test("should return 422 without valid body", async () => {
     const response = await request(server)
       .post(ApiEndpoint.GROUP)
-      .send(groupRequest);
-    expect(response.status).toEqual(401);
+      .set("Authorization", `Bearer ${getJWT(UserGroup.USER, "testuser")}`);
+    expect(response.status).toEqual(422);
   });
 
   test("should create group", async () => {
@@ -122,7 +118,6 @@ describe(`POST ${ApiEndpoint.GROUP}`, () => {
 
     const groupRequest: PostCreateGroupRequest = {
       groupCode: mockUser.serial,
-      username: mockUser.username,
     };
 
     const response = await request(server)
@@ -140,22 +135,19 @@ describe(`POST ${ApiEndpoint.GROUP}`, () => {
 });
 
 describe(`POST ${ApiEndpoint.JOIN_GROUP}`, () => {
-  test("should return 422 without valid body", async () => {
+  test("should return 401 without valid authorization", async () => {
     const response = await request(server).post(ApiEndpoint.JOIN_GROUP);
-    expect(response.status).toEqual(422);
+    expect(response.status).toEqual(401);
   });
 
-  test("should return 401 without valid authorization", async () => {
-    const groupRequest: PostJoinGroupRequest = {
-      groupCode: "1234",
-      ownSerial: "1234",
-      username: "testuser",
-    };
-
+  test("should return 422 without valid body", async () => {
     const response = await request(server)
       .post(ApiEndpoint.JOIN_GROUP)
-      .send(groupRequest);
-    expect(response.status).toEqual(401);
+      .set(
+        "Authorization",
+        `Bearer ${getJWT(UserGroup.USER, mockUser2.username)}`
+      );
+    expect(response.status).toEqual(422);
   });
 
   test("should join group", async () => {
@@ -171,7 +163,6 @@ describe(`POST ${ApiEndpoint.JOIN_GROUP}`, () => {
     const groupRequest: PostJoinGroupRequest = {
       groupCode: mockUser.serial,
       ownSerial: mockUser2.serial,
-      username: mockUser2.username,
     };
 
     const response = await request(server)
@@ -204,7 +195,6 @@ describe(`POST ${ApiEndpoint.JOIN_GROUP}`, () => {
     const groupRequest: PostJoinGroupRequest = {
       groupCode: mockUser.serial,
       ownSerial: mockUser2.serial,
-      username: mockUser2.username,
     };
 
     const response = await request(server)
@@ -222,19 +212,8 @@ describe(`POST ${ApiEndpoint.JOIN_GROUP}`, () => {
 });
 
 describe(`POST ${ApiEndpoint.LEAVE_GROUP}`, () => {
-  test("should return 422 without valid body", async () => {
-    const response = await request(server).post(ApiEndpoint.LEAVE_GROUP);
-    expect(response.status).toEqual(422);
-  });
-
   test("should return 401 without valid authorization", async () => {
-    const groupRequest: PostLeaveGroupRequest = {
-      username: "testuser",
-    };
-
-    const response = await request(server)
-      .post(ApiEndpoint.LEAVE_GROUP)
-      .send(groupRequest);
+    const response = await request(server).post(ApiEndpoint.LEAVE_GROUP);
     expect(response.status).toEqual(401);
   });
 
@@ -242,13 +221,8 @@ describe(`POST ${ApiEndpoint.LEAVE_GROUP}`, () => {
     await saveUser({ ...mockUser, groupCode: mockUser.serial });
     await saveUser({ ...mockUser2, groupCode: mockUser.serial });
 
-    const groupRequest: PostLeaveGroupRequest = {
-      username: mockUser2.username,
-    };
-
     const response = await request(server)
       .post(ApiEndpoint.LEAVE_GROUP)
-      .send(groupRequest)
       .set(
         "Authorization",
         `Bearer ${getJWT(UserGroup.USER, mockUser2.username)}`
@@ -261,21 +235,19 @@ describe(`POST ${ApiEndpoint.LEAVE_GROUP}`, () => {
 });
 
 describe(`POST ${ApiEndpoint.CLOSE_GROUP}`, () => {
-  test("should return 422 without valid body", async () => {
+  test("should return 401 without valid authorization", async () => {
     const response = await request(server).post(ApiEndpoint.CLOSE_GROUP);
-    expect(response.status).toEqual(422);
+    expect(response.status).toEqual(401);
   });
 
-  test("should return 401 without valid authorization", async () => {
-    const groupRequest: PostCloseGroupRequest = {
-      groupCode: "1234",
-      username: "testuser",
-    };
-
+  test("should return 422 without valid body", async () => {
     const response = await request(server)
       .post(ApiEndpoint.CLOSE_GROUP)
-      .send(groupRequest);
-    expect(response.status).toEqual(401);
+      .set(
+        "Authorization",
+        `Bearer ${getJWT(UserGroup.USER, mockUser.username)}`
+      );
+    expect(response.status).toEqual(422);
   });
 
   test("should close group and remove all group members", async () => {
@@ -284,7 +256,6 @@ describe(`POST ${ApiEndpoint.CLOSE_GROUP}`, () => {
 
     const groupRequest: PostCloseGroupRequest = {
       groupCode: mockUser.serial,
-      username: mockUser.username,
     };
 
     const response = await request(server)

--- a/server/src/features/user/group/groupController.ts
+++ b/server/src/features/user/group/groupController.ts
@@ -11,8 +11,6 @@ import {
   PostCreateGroupRequestSchema,
   PostJoinGroupRequest,
   PostJoinGroupRequestSchema,
-  PostLeaveGroupRequest,
-  PostLeaveGroupRequestSchema,
 } from "shared/typings/api/groups";
 import { isAuthorized } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
@@ -30,6 +28,11 @@ export const postCreateGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.GROUP}`);
 
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
+    return res.sendStatus(401);
+  }
+
   let groupRequest: PostCreateGroupRequest;
   try {
     groupRequest = PostCreateGroupRequestSchema.parse(req.body);
@@ -42,11 +45,7 @@ export const postCreateGroup = async (
     return res.sendStatus(422);
   }
 
-  const { username, groupCode } = groupRequest;
-
-  if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
-    return res.sendStatus(401);
-  }
+  const { groupCode } = groupRequest;
 
   const response = await createGroup(username, groupCode);
   return res.json(response);
@@ -57,6 +56,11 @@ export const postJoinGroup = async (
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.JOIN_GROUP}`);
+
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
+    return res.sendStatus(401);
+  }
 
   let groupRequest: PostJoinGroupRequest;
   try {
@@ -70,37 +74,20 @@ export const postJoinGroup = async (
     return res.sendStatus(422);
   }
 
-  const { username, groupCode, ownSerial } = groupRequest;
-
-  if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
-    return res.sendStatus(401);
-  }
+  const { groupCode, ownSerial } = groupRequest;
 
   const response = await joinGroup(username, groupCode, ownSerial);
   return res.json(response);
 };
 
 export const postLeaveGroup = async (
-  req: Request<{}, {}, PostLeaveGroupRequest>,
+  req: Request<{}, {}, {}>,
   res: Response
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.LEAVE_GROUP}`);
 
-  let groupRequest: PostLeaveGroupRequest;
-  try {
-    groupRequest = PostLeaveGroupRequestSchema.parse(req.body);
-  } catch (error) {
-    if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postLeaveGroup parameters: ${error.message}`
-      );
-    }
-    return res.sendStatus(422);
-  }
-
-  const { username } = groupRequest;
-
-  if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
     return res.sendStatus(401);
   }
 
@@ -114,6 +101,11 @@ export const postCloseGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.CLOSE_GROUP}`);
 
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
+    return res.sendStatus(401);
+  }
+
   let groupRequest: PostCloseGroupRequest;
   try {
     groupRequest = PostCloseGroupRequestSchema.parse(req.body);
@@ -126,11 +118,7 @@ export const postCloseGroup = async (
     return res.sendStatus(422);
   }
 
-  const { username, groupCode } = groupRequest;
-
-  if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
-    return res.sendStatus(401);
-  }
+  const { groupCode } = groupRequest;
 
   const response = await closeGroup(groupCode, username);
   return res.json(response);
@@ -142,6 +130,11 @@ export const getGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.GROUP}`);
 
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
+    return res.sendStatus(401);
+  }
+
   let parameters;
   try {
     parameters = GetGroupRequestSchema.parse(req.query);
@@ -149,11 +142,7 @@ export const getGroup = async (
     return res.sendStatus(422);
   }
 
-  const { groupCode, username } = parameters;
-
-  if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
-    return res.sendStatus(401);
-  }
+  const { groupCode } = parameters;
 
   const response = await fetchGroup(groupCode);
   return res.json(response);

--- a/server/src/features/user/group/groupController.ts
+++ b/server/src/features/user/group/groupController.ts
@@ -12,7 +12,7 @@ import {
   PostJoinGroupRequest,
   PostJoinGroupRequestSchema,
 } from "shared/typings/api/groups";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import {
   closeGroup,
@@ -28,7 +28,10 @@ export const postCreateGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.GROUP}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -55,7 +58,10 @@ export const postJoinGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.JOIN_GROUP}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -82,7 +88,10 @@ export const postLeaveGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.LEAVE_GROUP}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -97,7 +106,10 @@ export const postCloseGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.CLOSE_GROUP}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -124,7 +136,10 @@ export const getGroup = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.GROUP}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/user/group/groupController.ts
+++ b/server/src/features/user/group/groupController.ts
@@ -33,19 +33,17 @@ export const postCreateGroup = async (
     return res.sendStatus(401);
   }
 
-  let groupRequest: PostCreateGroupRequest;
+  let body;
   try {
-    groupRequest = PostCreateGroupRequestSchema.parse(req.body);
+    body = PostCreateGroupRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postCreateGroup parameters: ${error.message}`
-      );
+      logger.error(`Error validating postCreateGroup body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const { groupCode } = groupRequest;
+  const { groupCode } = body;
 
   const response = await createGroup(username, groupCode);
   return res.json(response);
@@ -62,19 +60,17 @@ export const postJoinGroup = async (
     return res.sendStatus(401);
   }
 
-  let groupRequest: PostJoinGroupRequest;
+  let body;
   try {
-    groupRequest = PostJoinGroupRequestSchema.parse(req.body);
+    body = PostJoinGroupRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postJoinGroup parameters: ${error.message}`
-      );
+      logger.error(`Error validating postJoinGroup body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const { groupCode, ownSerial } = groupRequest;
+  const { groupCode, ownSerial } = body;
 
   const response = await joinGroup(username, groupCode, ownSerial);
   return res.json(response);
@@ -106,19 +102,17 @@ export const postCloseGroup = async (
     return res.sendStatus(401);
   }
 
-  let groupRequest: PostCloseGroupRequest;
+  let body;
   try {
-    groupRequest = PostCloseGroupRequestSchema.parse(req.body);
+    body = PostCloseGroupRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postCloseGroup parameters: ${error.message}`
-      );
+      logger.error(`Error validating postCloseGroup body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const { groupCode } = groupRequest;
+  const { groupCode } = body;
 
   const response = await closeGroup(groupCode, username);
   return res.json(response);
@@ -135,14 +129,17 @@ export const getGroup = async (
     return res.sendStatus(401);
   }
 
-  let parameters;
+  let params;
   try {
-    parameters = GetGroupRequestSchema.parse(req.query);
+    params = GetGroupRequestSchema.parse(req.query);
   } catch (error) {
+    if (error instanceof ZodError) {
+      logger.error(`Error validating getGroup params: ${error.message}`);
+    }
     return res.sendStatus(422);
   }
 
-  const { groupCode } = parameters;
+  const { groupCode } = params;
 
   const response = await fetchGroup(groupCode);
   return res.json(response);

--- a/server/src/features/user/login/loginController.ts
+++ b/server/src/features/user/login/loginController.ts
@@ -14,17 +14,17 @@ export const postLogin = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.LOGIN}`);
 
-  let parameters;
+  let body;
   try {
-    parameters = PostLoginRequestSchema.parse(req.body);
+    body = PostLoginRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(`Error validating postLogin parameters: ${error.message}`);
+      logger.error(`Error validating postLogin body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const { username, password } = parameters;
+  const { username, password } = body;
   const response = await login(username, password);
   return res.json(response);
 };

--- a/server/src/features/user/session-restore/sessionRestoreService.ts
+++ b/server/src/features/user/session-restore/sessionRestoreService.ts
@@ -33,7 +33,7 @@ export const loginWithJwt = async (
     };
   }
 
-  const jwtResponse = verifyJWT(jwt, userGroup, username);
+  const jwtResponse = verifyJWT(jwt, userGroup);
 
   if (jwtResponse.status === "error") {
     return {

--- a/server/src/features/user/signed-game/signedGameController.ts
+++ b/server/src/features/user/signed-game/signedGameController.ts
@@ -16,6 +16,11 @@ export const postSignedGames = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNED_GAME}`);
 
+  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  if (!username) {
+    return res.sendStatus(401);
+  }
+
   let parameters;
   try {
     parameters = PostSignedGamesRequestSchema.parse(req.body);
@@ -28,11 +33,7 @@ export const postSignedGames = async (
     return res.sendStatus(422);
   }
 
-  const { selectedGames, username, startTime } = parameters;
-
-  if (!isAuthorized(req.headers.authorization, UserGroup.USER, username)) {
-    return res.sendStatus(401);
-  }
+  const { selectedGames, startTime } = parameters;
 
   const response = await storeSignedGames(selectedGames, username, startTime);
   return res.json(response);

--- a/server/src/features/user/signed-game/signedGameController.ts
+++ b/server/src/features/user/signed-game/signedGameController.ts
@@ -6,7 +6,7 @@ import {
   PostSignedGamesRequest,
   PostSignedGamesRequestSchema,
 } from "shared/typings/api/myGames";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import { storeSignedGames } from "server/features/user/signed-game/signedGameService";
 
@@ -16,7 +16,10 @@ export const postSignedGames = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.SIGNED_GAME}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/user/signed-game/signedGameController.ts
+++ b/server/src/features/user/signed-game/signedGameController.ts
@@ -21,19 +21,17 @@ export const postSignedGames = async (
     return res.sendStatus(401);
   }
 
-  let parameters;
+  let body;
   try {
-    parameters = PostSignedGamesRequestSchema.parse(req.body);
+    body = PostSignedGamesRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postSignedGames parameters: ${error.message}`
-      );
+      logger.error(`Error validating postSignedGames body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const { selectedGames, startTime } = parameters;
+  const { selectedGames, startTime } = body;
 
   const response = await storeSignedGames(selectedGames, username, startTime);
   return res.json(response);

--- a/server/src/features/user/signup-message/signupMessageController.ts
+++ b/server/src/features/user/signup-message/signupMessageController.ts
@@ -11,7 +11,8 @@ export const getSignupMessages = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.SIGNUP_MESSAGE}`);
 
-  if (!isAuthorized(req.headers.authorization, UserGroup.HELP, "helper")) {
+  const username = isAuthorized(req.headers.authorization, UserGroup.HELP);
+  if (!username) {
     return res.sendStatus(401);
   }
 

--- a/server/src/features/user/signup-message/signupMessageController.ts
+++ b/server/src/features/user/signup-message/signupMessageController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { UserGroup } from "shared/typings/models/user";
 import { fetchSignupMessages } from "server/features/user/signup-message/signupMessageService";
 
@@ -11,7 +11,10 @@ export const getSignupMessages = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.SIGNUP_MESSAGE}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.HELP);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.HELP
+  );
   if (!username) {
     return res.sendStatus(401);
   }

--- a/server/src/features/user/userController.test.ts
+++ b/server/src/features/user/userController.test.ts
@@ -29,24 +29,11 @@ afterAll(async () => {
 });
 
 describe(`GET ${ApiEndpoint.USERS}`, () => {
-  test("should return 422 without valid body", async () => {
-    const { server } = await startTestServer(mongoServer.getUri());
-
-    try {
-      const response = await request(server).get(ApiEndpoint.USERS);
-      expect(response.status).toEqual(422);
-    } finally {
-      await stopTestServer(server);
-    }
-  });
-
   test("should return 401 without valid authorization", async () => {
     const { server } = await startTestServer(mongoServer.getUri());
 
     try {
-      const response = await request(server)
-        .get(ApiEndpoint.USERS)
-        .query({ username: "testuser" });
+      const response = await request(server).get(ApiEndpoint.USERS);
       expect(response.status).toEqual(401);
     } finally {
       await stopTestServer(server);
@@ -149,6 +136,17 @@ describe(`POST ${ApiEndpoint.USERS}`, () => {
 });
 
 describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
+  test("should return 401 without valid authorization", async () => {
+    const { server } = await startTestServer(mongoServer.getUri());
+
+    try {
+      const response = await request(server).post(ApiEndpoint.USERS_PASSWORD);
+      expect(response.status).toEqual(401);
+    } finally {
+      await stopTestServer(server);
+    }
+  });
+
   test("should return 422 without valid body", async () => {
     const { server } = await startTestServer(mongoServer.getUri());
 
@@ -157,25 +155,9 @@ describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
         .post(ApiEndpoint.USERS_PASSWORD)
         .send({
           username: "testuser",
-        });
+        })
+        .set("Authorization", `Bearer ${getJWT(UserGroup.USER, "testuser")}`);
       expect(response.status).toEqual(422);
-    } finally {
-      await stopTestServer(server);
-    }
-  });
-
-  test("should return 401 without valid authorization", async () => {
-    const { server } = await startTestServer(mongoServer.getUri());
-
-    try {
-      const response = await request(server)
-        .post(ApiEndpoint.USERS_PASSWORD)
-        .send({
-          username: "testuser",
-          password: "testpass",
-          requester: "testuser",
-        });
-      expect(response.status).toEqual(401);
     } finally {
       await stopTestServer(server);
     }
@@ -188,9 +170,8 @@ describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
       const response = await request(server)
         .post(ApiEndpoint.USERS_PASSWORD)
         .send({
-          username: "testuser",
+          userToUpdateUsername: "testuser",
           password: "testpass",
-          requester: "testuser",
         })
         .set("Authorization", `Bearer ${getJWT(UserGroup.USER, "testuser")}`);
       expect(response.status).toEqual(200);
@@ -207,9 +188,8 @@ describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
       const response = await request(server)
         .post(ApiEndpoint.USERS_PASSWORD)
         .send({
-          username: "another_user",
+          userToUpdateUsername: "another_user",
           password: "testpass",
-          requester: "testuser",
         })
         .set("Authorization", `Bearer ${getJWT(UserGroup.USER, "testuser")}`);
       expect(response.status).toEqual(401);
@@ -225,9 +205,8 @@ describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
       const response = await request(server)
         .post(ApiEndpoint.USERS_PASSWORD)
         .send({
-          username: "another_user",
+          userToUpdateUsername: "another_user",
           password: "testpass",
-          requester: "helper",
         })
         .set("Authorization", `Bearer ${getJWT(UserGroup.HELP, "helper")}`);
       expect(response.status).toEqual(200);
@@ -244,9 +223,8 @@ describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
       const response = await request(server)
         .post(ApiEndpoint.USERS_PASSWORD)
         .send({
-          username: "admin",
+          userToUpdateUsername: "admin",
           password: "testpass",
-          requester: "helper",
         })
         .set("Authorization", `Bearer ${getJWT(UserGroup.HELP, "helper")}`);
       expect(response.status).toEqual(200);
@@ -256,9 +234,8 @@ describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
       const response2 = await request(server)
         .post(ApiEndpoint.USERS_PASSWORD)
         .send({
-          username: "helper",
+          userToUpdateUsername: "helper",
           password: "testpass",
-          requester: "helper",
         })
         .set("Authorization", `Bearer ${getJWT(UserGroup.HELP, "helper")}`);
       expect(response2.status).toEqual(200);
@@ -276,9 +253,8 @@ describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
       const response = await request(server)
         .post(ApiEndpoint.USERS_PASSWORD)
         .send({
-          username: "admin",
+          userToUpdateUsername: "admin",
           password: "testpass",
-          requester: "admin",
         })
         .set("Authorization", `Bearer ${getJWT(UserGroup.ADMIN, "admin")}`);
       expect(response.status).toEqual(200);
@@ -287,9 +263,8 @@ describe(`POST ${ApiEndpoint.USERS_PASSWORD}`, () => {
       const response2 = await request(server)
         .post(ApiEndpoint.USERS_PASSWORD)
         .send({
-          username: "helper",
+          userToUpdateUsername: "helper",
           password: "testpass",
-          requester: "admin",
         })
         .set("Authorization", `Bearer ${getJWT(UserGroup.ADMIN, "admin")}`);
       expect(response2.status).toEqual(200);

--- a/server/src/features/user/userController.ts
+++ b/server/src/features/user/userController.ts
@@ -7,7 +7,7 @@ import {
   storeUserPassword,
 } from "server/features/user/userService";
 import { UserGroup } from "shared/typings/models/user";
-import { isAuthorized } from "server/utils/authHeader";
+import { getAuthorizedUsername } from "server/utils/authHeader";
 import { logger } from "server/utils/logger";
 import { ApiEndpoint } from "shared/constants/apiEndpoints";
 import { sharedConfig } from "shared/config/sharedConfig";
@@ -55,7 +55,7 @@ export const postUserPassword = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.USERS_PASSWORD}`);
 
-  const requesterUsername = isAuthorized(req.headers.authorization, [
+  const requesterUsername = getAuthorizedUsername(req.headers.authorization, [
     UserGroup.USER,
     UserGroup.HELP,
     UserGroup.ADMIN,
@@ -98,7 +98,10 @@ export const getUser = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.USERS}`);
 
-  const username = isAuthorized(req.headers.authorization, UserGroup.USER);
+  const username = getAuthorizedUsername(
+    req.headers.authorization,
+    UserGroup.USER
+  );
   if (!username) {
     return res.sendStatus(401);
   }
@@ -113,7 +116,7 @@ export const getUserBySerialOrUsername = async (
 ): Promise<Response> => {
   logger.info(`API call: GET ${ApiEndpoint.USERS_BY_SERIAL_OR_USERNAME}`);
 
-  const username = isAuthorized(req.headers.authorization, [
+  const username = getAuthorizedUsername(req.headers.authorization, [
     UserGroup.HELP,
     UserGroup.ADMIN,
   ]);

--- a/server/src/features/user/userController.ts
+++ b/server/src/features/user/userController.ts
@@ -27,23 +27,23 @@ export const postUser = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.USERS}`);
 
-  let parameters;
+  let body;
   try {
-    parameters = PostUserRequestSchema.parse(req.body);
+    body = PostUserRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(`Error validating postUser parameters: ${error.message}`);
+      logger.error(`Error validating postUser body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const { username, password } = parameters;
+  const { username, password } = body;
   let serial;
   if (!sharedConfig.requireRegistrationCode) {
     const serialDoc = await createSerial();
     serial = serialDoc[0].serial;
   } else {
-    serial = parameters.serial;
+    serial = body.serial;
   }
   const response = await storeUser(username, password, serial);
   return res.json(response);
@@ -64,19 +64,17 @@ export const postUserPassword = async (
     return res.sendStatus(401);
   }
 
-  let parameters;
+  let body;
   try {
-    parameters = PostUpdateUserPasswordRequestSchema.parse(req.body);
+    body = PostUpdateUserPasswordRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postUserPassword parameters: ${error.message}`
-      );
+      logger.error(`Error validating postUserPassword body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const { userToUpdateUsername, password } = parameters;
+  const { userToUpdateUsername, password } = body;
 
   if (
     requesterUsername !== userToUpdateUsername &&
@@ -123,19 +121,19 @@ export const getUserBySerialOrUsername = async (
     return res.sendStatus(401);
   }
 
-  let parameters;
+  let params;
   try {
-    parameters = GetUserBySerialRequestSchema.parse(req.query);
+    params = GetUserBySerialRequestSchema.parse(req.query);
   } catch (error) {
     if (error instanceof ZodError) {
       logger.error(
-        `Error validating getUserBySerialOrUsername parameters: ${error.message}`
+        `Error validating getUserBySerialOrUsername params: ${error.message}`
       );
     }
     return res.sendStatus(422);
   }
 
-  const { searchTerm } = parameters;
+  const { searchTerm } = params;
 
   if (!searchTerm) {
     return res.sendStatus(422);

--- a/server/src/test/test-settings/testSettingsController.ts
+++ b/server/src/test/test-settings/testSettingsController.ts
@@ -27,18 +27,16 @@ export const postTestSettings = async (
 ): Promise<Response> => {
   logger.info(`API call: POST ${ApiEndpoint.TEST_SETTINGS}`);
 
-  let testSettings;
+  let body;
   try {
-    testSettings = PostTestSettingsRequestSchema.parse(req.body);
+    body = PostTestSettingsRequestSchema.parse(req.body);
   } catch (error) {
     if (error instanceof ZodError) {
-      logger.error(
-        `Error validating postTestSettings parameters: ${error.message}`
-      );
+      logger.error(`Error validating postTestSettings body: ${error.message}`);
     }
     return res.sendStatus(422);
   }
 
-  const response = await updateTestSettings(testSettings);
+  const response = await updateTestSettings(body);
   return res.json(response);
 };

--- a/server/src/utils/authHeader.ts
+++ b/server/src/utils/authHeader.ts
@@ -2,7 +2,7 @@ import { getJwtResponse } from "server/utils/jwt";
 import { logger } from "server/utils/logger";
 import { UserGroup } from "shared/typings/models/user";
 
-export const isAuthorized = (
+export const getAuthorizedUsername = (
   authHeader: string | undefined,
   requiredUserGroup: UserGroup | UserGroup[]
 ): string | null => {

--- a/server/src/utils/authHeader.ts
+++ b/server/src/utils/authHeader.ts
@@ -4,26 +4,25 @@ import { UserGroup } from "shared/typings/models/user";
 
 export const isAuthorized = (
   authHeader: string | undefined,
-  requiredUserGroup: UserGroup | UserGroup[],
-  username: string
-): boolean => {
+  requiredUserGroup: UserGroup | UserGroup[]
+): string | null => {
   logger.debug(`Auth: Require jwt for user group "${requiredUserGroup}"`);
 
   if (!authHeader || authHeader.split(" ")[0] !== "Bearer") {
     logger.info(`Auth: No auth header`);
-    return false;
+    return null;
   }
 
   // Strip 'bearer' from authHeader
   const jwt = authHeader.split("Bearer ")[1];
 
-  const jwtResponse = getJwtResponse(jwt, requiredUserGroup, username);
+  const jwtResponse = getJwtResponse(jwt, requiredUserGroup);
 
   if (jwtResponse.status === "error") {
     logger.info(`Auth: Invalid jwt for user group "${requiredUserGroup}"`);
-    return false;
+    return null;
   }
 
   logger.debug(`Auth: Valid jwt for user group "${requiredUserGroup}" `);
-  return true;
+  return jwtResponse.username;
 };

--- a/server/src/utils/jwt.ts
+++ b/server/src/utils/jwt.ts
@@ -16,11 +16,7 @@ export const getJWT = (userGroup: UserGroup, username: string): string => {
   return jsonwebtoken.sign(payload, getSecret(userGroup), options);
 };
 
-export const verifyJWT = (
-  jwt: string,
-  userGroup: UserGroup,
-  username: string
-): JWTResult => {
+export const verifyJWT = (jwt: string, userGroup: UserGroup): JWTResult => {
   let result;
   try {
     result = jsonwebtoken.verify(jwt, getSecret(userGroup)) as JWTResult;
@@ -35,25 +31,24 @@ export const verifyJWT = (
         exp: 0,
       };
     }
+
+    return {
+      status: "error",
+      message: "unknown jwt error",
+      username: "",
+      userGroup: "",
+      iat: 0,
+      exp: 0,
+    };
   }
 
-  if (result?.username === username)
-    return {
-      username: result.username,
-      userGroup: result.userGroup,
-      iat: result.iat,
-      exp: result.exp,
-      status: "success",
-      message: "success",
-    };
-
   return {
-    status: "error",
-    message: "unknown jwt error",
-    username: "",
-    userGroup: "",
-    iat: 0,
-    exp: 0,
+    username: result.username,
+    userGroup: result.userGroup,
+    iat: result.iat,
+    exp: result.exp,
+    status: "success",
+    message: "success",
   };
 };
 
@@ -74,12 +69,11 @@ const getSecret = (userGroup: UserGroup): string => {
 
 export const getJwtResponse = (
   jwt: string,
-  requiredUserGroup: UserGroup | UserGroup[],
-  username: string
+  requiredUserGroup: UserGroup | UserGroup[]
 ): JWTResult => {
   if (Array.isArray(requiredUserGroup)) {
     const responses = requiredUserGroup.map((userGroup) => {
-      return verifyJWT(jwt, userGroup, username);
+      return verifyJWT(jwt, userGroup);
     });
 
     return (
@@ -88,5 +82,5 @@ export const getJwtResponse = (
     );
   }
 
-  return verifyJWT(jwt, requiredUserGroup, username);
+  return verifyJWT(jwt, requiredUserGroup);
 };

--- a/shared/typings/api/favorite.ts
+++ b/shared/typings/api/favorite.ts
@@ -4,7 +4,6 @@ import { Game } from "shared/typings/models/game";
 // POST favorite
 
 export const PostFavoriteRequestSchema = z.object({
-  username: z.string(),
   favoritedGameIds: z.array(z.string()),
 });
 

--- a/shared/typings/api/feedback.ts
+++ b/shared/typings/api/feedback.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 export const PostFeedbackRequestSchema = z.object({
   gameId: z.string(),
   feedback: z.string(),
-  username: z.string(),
 });
 
 export type PostFeedbackRequest = z.infer<typeof PostFeedbackRequestSchema>;

--- a/shared/typings/api/groups.ts
+++ b/shared/typings/api/groups.ts
@@ -6,7 +6,6 @@ import { GroupMember } from "shared/typings/models/groups";
 
 export const PostCreateGroupRequestSchema = z.object({
   groupCode: z.string(),
-  username: z.string(),
 });
 
 export type PostCreateGroupRequest = z.infer<
@@ -28,7 +27,6 @@ export interface PostCreateGroupError extends ApiError {
 export const PostJoinGroupRequestSchema = z.object({
   groupCode: z.string(),
   ownSerial: z.string(),
-  username: z.string(),
 });
 
 export type PostJoinGroupRequest = z.infer<typeof PostJoinGroupRequestSchema>;
@@ -47,12 +45,6 @@ export interface PostJoinGroupError extends ApiError {
 
 // POST: Leave group
 
-export const PostLeaveGroupRequestSchema = z.object({
-  username: z.string(),
-});
-
-export type PostLeaveGroupRequest = z.infer<typeof PostLeaveGroupRequestSchema>;
-
 export type PostLeaveGroupResponse = PostCreateGroupResponse;
 
 export interface PostLeaveGroupError extends ApiError {
@@ -63,7 +55,6 @@ export interface PostLeaveGroupError extends ApiError {
 
 export const PostCloseGroupRequestSchema = z.object({
   groupCode: z.string(),
-  username: z.string(),
 });
 
 export type PostCloseGroupRequest = z.infer<typeof PostCloseGroupRequestSchema>;
@@ -78,7 +69,6 @@ export interface PostCloseGroupError extends ApiError {
 
 export const GetGroupRequestSchema = z.object({
   groupCode: z.string(),
-  username: z.string(),
 });
 
 export type GetGroupRequest = z.infer<typeof GetGroupRequestSchema>;

--- a/shared/typings/api/myGames.ts
+++ b/shared/typings/api/myGames.ts
@@ -7,7 +7,6 @@ import { GameSchema } from "shared/typings/models/game";
 // POST signed games
 
 export const PostSignedGamesRequestSchema = z.object({
-  username: z.string(),
   selectedGames: z.array(
     z.object({
       gameDetails: GameSchema,

--- a/shared/typings/api/users.ts
+++ b/shared/typings/api/users.ts
@@ -12,12 +12,6 @@ import { sharedConfig } from "shared/config/sharedConfig";
 
 // GET user
 
-export const GetUserRequestSchema = z.object({
-  username: z.string(),
-});
-
-export type GetUserRequest = z.infer<typeof GetUserRequestSchema>;
-
 export interface GetUserResponse {
   games: UserGames;
   message: string;
@@ -60,9 +54,8 @@ export interface PostUserError extends ApiError {
 // POST update user password
 
 export const PostUpdateUserPasswordRequestSchema = z.object({
-  username: z.string(),
+  userToUpdateUsername: z.string(),
   password: z.string(),
-  requester: z.string(),
 });
 
 export type PostUpdateUserPasswordRequest = z.infer<

--- a/shared/typings/models/user.ts
+++ b/shared/typings/models/user.ts
@@ -29,3 +29,8 @@ export interface UserGames {
   favoritedGames: readonly Game[];
   signedGames: readonly SelectedGame[];
 }
+
+export interface NewFavorite {
+  username: string;
+  favoritedGameIds: string[];
+}


### PR DESCRIPTION
* Haetaan API-kutsun tekijän `username` JWT:stä. Sen avulla rajataan, että käyttäjä voi ladata/muokata vain omia tietojaan.
  * Oikeasti haluttaisiin, että tässä olisi `username` sijaan `userId`  mutta joku toinen kerta 😄 
* Aikaisemmin `username` passattiin API-kutsussa erillisenä arvona ja sitten tsekattiin, onko passattu arvo ja JWT:n arvo samat, missä ei ole kauheesti järkeä 😅
  * Tämän takia API-kutsun body piti myös parsia ensin ja vasta sitten tehtiin JWT:n avulla autorisointi. Loogisesti halutaan aina ensin tsekata autorisointi ennen kuin tehdään mitään muuta.
* Käytännön vaikutuksena API-kutsuihin ei tosiaan tarvitse enää passata `username`-arvoa, koska se luetaan bäkkärillä JWT:stä
* Tää on yksi askel sitä kohti, että olisi joku järkevämpi auth-middleware