### PR TITLE
Sent caught errors to Sentry and use JSON format on prod/staging

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -47,7 +47,7 @@
     "node-schedule": "2.1.1",
     "ts-node": "10.9.1",
     "winston": "3.8.2",
-    "winston-daily-rotate-file": "4.7.1"
+    "winston-transport-sentry-node": "2.7.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "2.4.2",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -6,7 +6,6 @@ enum GameUpdateMethod {
 interface Config {
   port: number;
   debug: boolean;
-  logDir: string;
   enableAccessLog: boolean;
   dbConnString: string;
   dbName: string;
@@ -46,7 +45,6 @@ const commonConfig = {
   debug: false,
 
   // Logging
-  logDir: "./logs",
   enableAccessLog: false,
 
   // App settings

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -34,6 +34,7 @@ interface Config {
   autoAssignInterval: string;
   useTestTime: boolean;
   localKompassiFile: string;
+  consoleLogFormatJson: boolean;
 }
 
 const commonConfig = {
@@ -83,6 +84,7 @@ const prodConfig = {
   PADG_ASSIGNMENT_ROUNDS: 300,
   RANDOM_ASSIGNMENT_ROUNDS: 300,
   updateGamePopularityEnabled: true,
+  consoleLogFormatJson: true,
 
   // Dev
   useTestTime: false,
@@ -113,6 +115,7 @@ const stagingConfig = {
   PADG_ASSIGNMENT_ROUNDS: 300,
   RANDOM_ASSIGNMENT_ROUNDS: 300,
   updateGamePopularityEnabled: true,
+  consoleLogFormatJson: true,
 
   // Dev
   useTestTime: true,
@@ -144,6 +147,7 @@ const devConfig = {
   PADG_ASSIGNMENT_ROUNDS: 300,
   RANDOM_ASSIGNMENT_ROUNDS: 10,
   updateGamePopularityEnabled: true,
+  consoleLogFormatJson: false,
 
   // Dev
   useTestTime: true,

--- a/server/src/utils/sentry.ts
+++ b/server/src/utils/sentry.ts
@@ -16,6 +16,9 @@ export const initSentry = (app: Express, enableSentry: boolean): void => {
         // To trace all requests to the default router
         app,
       }),
+      new Integrations.OnUnhandledRejection({
+        mode: "none",
+      }),
     ],
     tracesSampleRate: sharedConfig.tracesSampleRate,
     environment: process.env.SETTINGS,
@@ -51,7 +54,7 @@ export const initSentry = (app: Express, enableSentry: boolean): void => {
   );
 };
 
-const getDsn = (enableSentry: boolean): string | undefined => {
+export const getDsn = (enableSentry: boolean): string | undefined => {
   if (!enableSentry) return undefined;
   switch (process.env.SETTINGS) {
     case "production":

--- a/shared/config/sharedConfig.ts
+++ b/shared/config/sharedConfig.ts
@@ -128,7 +128,7 @@ export const sharedConfig: SharedConfig = {
 
   // Sentry
   tracesSampleRate: 0.0,
-  enableSentryInDev: true,
+  enableSentryInDev: false,
 
   // Test values
   CONVENTION_START_TIME: "2022-07-29T12:00:00Z", // UTC date

--- a/shared/config/sharedConfig.ts
+++ b/shared/config/sharedConfig.ts
@@ -128,7 +128,7 @@ export const sharedConfig: SharedConfig = {
 
   // Sentry
   tracesSampleRate: 0.0,
-  enableSentryInDev: false,
+  enableSentryInDev: true,
 
   // Test values
   CONVENTION_START_TIME: "2022-07-29T12:00:00Z", // UTC date

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,6 +3021,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/tracing@npm:7.53.1":
+  version: 7.53.1
+  resolution: "@sentry-internal/tracing@npm:7.53.1"
+  dependencies:
+    "@sentry/core": 7.53.1
+    "@sentry/types": 7.53.1
+    "@sentry/utils": 7.53.1
+    tslib: ^1.9.3
+  checksum: 99fadf422e619faeea436a96b37088ba10850f8e77fca10d7fea6de0c3f1d60b0e8ec1da3b9230f4213fa25f044c99aba585562447ddca0a443d7cbd88c3b81d
+  languageName: node
+  linkType: hard
+
 "@sentry/browser@npm:7.52.1":
   version: 7.52.1
   resolution: "@sentry/browser@npm:7.52.1"
@@ -3046,6 +3058,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/core@npm:7.53.1":
+  version: 7.53.1
+  resolution: "@sentry/core@npm:7.53.1"
+  dependencies:
+    "@sentry/types": 7.53.1
+    "@sentry/utils": 7.53.1
+    tslib: ^1.9.3
+  checksum: 5d42bc30a59cb4459eb99441b631e3f9daec5b2e98c24377aae0329127f8c474a9c32353a96e3f4765e3fb18370756e85f6b873cd26bd591e0040917b7fa9cf4
+  languageName: node
+  linkType: hard
+
 "@sentry/node@npm:7.52.1":
   version: 7.52.1
   resolution: "@sentry/node@npm:7.52.1"
@@ -3059,6 +3082,22 @@ __metadata:
     lru_map: ^0.3.3
     tslib: ^1.9.3
   checksum: 27db143a6a27b5e93414599fc75ecd30d4b5e003883adf15c695fdd8c5eab35d57eb2df63b5ed1a7898266015c39e9b42b58bc5aa7c9644148fcabba3aa55736
+  languageName: node
+  linkType: hard
+
+"@sentry/node@npm:^7.1.1":
+  version: 7.53.1
+  resolution: "@sentry/node@npm:7.53.1"
+  dependencies:
+    "@sentry-internal/tracing": 7.53.1
+    "@sentry/core": 7.53.1
+    "@sentry/types": 7.53.1
+    "@sentry/utils": 7.53.1
+    cookie: ^0.4.1
+    https-proxy-agent: ^5.0.0
+    lru_map: ^0.3.3
+    tslib: ^1.9.3
+  checksum: e1b3c342c75a2a5883d6f1a52bc975bd6fb06643d2c26fd302cc0cfd23ca09509374f8c3afbe16208d007dc862e58b96946125dfebd3ba5856aa791cff04cea2
   languageName: node
   linkType: hard
 
@@ -3095,6 +3134,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/types@npm:7.53.1":
+  version: 7.53.1
+  resolution: "@sentry/types@npm:7.53.1"
+  checksum: 5f76d7d66d5df5d48f66a755e18ae133ea02a9405093b652eb4921ca62c3114343561a2d8067f2be6d9df8dd32d10e30d3ce58150f795600680e6230fb136681
+  languageName: node
+  linkType: hard
+
 "@sentry/utils@npm:7.52.1":
   version: 7.52.1
   resolution: "@sentry/utils@npm:7.52.1"
@@ -3102,6 +3148,16 @@ __metadata:
     "@sentry/types": 7.52.1
     tslib: ^1.9.3
   checksum: 5e0b8c95db28350fcdcd871ad22c0d2eab4c541be4d5652b2c4018937640d8482fd3fc4fd02967ef5be367ee720735fbc902e50087746d6f59a2bbf2beaf2273
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:7.53.1":
+  version: 7.53.1
+  resolution: "@sentry/utils@npm:7.53.1"
+  dependencies:
+    "@sentry/types": 7.53.1
+    tslib: ^1.9.3
+  checksum: d9556f161a0eed0e1bb279bac12b99492b6212d9b6cabebbcb2d0f196f99b96c319305ec347d8f06382e2dde5782d5ba20a00f762fbfd4e8699e9100ef921804
   languageName: node
   linkType: hard
 
@@ -7225,15 +7281,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-stream-rotator@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "file-stream-rotator@npm:0.6.1"
-  dependencies:
-    moment: ^2.29.1
-  checksum: ebdf6a9e7ca886a50f4dafb2284d4569cefd5bdf4e4451ead25f4d68b7f9776b2620a3d110d534edd40935d1e17f37d818e2129303201870ff89c71b19b49ac1
-  languageName: node
-  linkType: hard
-
 "fill-range@npm:^7.0.1":
   version: 7.0.1
   resolution: "fill-range@npm:7.0.1"
@@ -9144,7 +9191,7 @@ __metadata:
     ts-node: 10.9.1
     ts-node-dev: 2.0.0
     winston: 3.8.2
-    winston-daily-rotate-file: 4.7.1
+    winston-transport-sentry-node: 2.7.0
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -10364,13 +10411,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.29.1":
-  version: 2.29.4
-  resolution: "moment@npm:2.29.4"
-  checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
-  languageName: node
-  linkType: hard
-
 "mongodb-connection-string-url@npm:^2.5.4, mongodb-connection-string-url@npm:^2.6.0":
   version: 2.6.0
   resolution: "mongodb-connection-string-url@npm:2.6.0"
@@ -10780,13 +10820,6 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
-  languageName: node
-  linkType: hard
-
-"object-hash@npm:^2.0.1":
-  version: 2.2.0
-  resolution: "object-hash@npm:2.2.0"
-  checksum: 55ba841e3adce9c4f1b9b46b41983eda40f854e0d01af2802d3ae18a7085a17168d6b81731d43fdf1d6bcbb3c9f9c56d22c8fea992203ad90a38d7d919bc28f1
   languageName: node
   linkType: hard
 
@@ -14587,17 +14620,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston-daily-rotate-file@npm:4.7.1":
-  version: 4.7.1
-  resolution: "winston-daily-rotate-file@npm:4.7.1"
+"winston-transport-sentry-node@npm:2.7.0":
+  version: 2.7.0
+  resolution: "winston-transport-sentry-node@npm:2.7.0"
   dependencies:
-    file-stream-rotator: ^0.6.1
-    object-hash: ^2.0.1
+    "@sentry/node": ^7.1.1
     triple-beam: ^1.3.0
+    tslib: ^2.3.1
+    winston: ^3.3.3
     winston-transport: ^4.4.0
-  peerDependencies:
-    winston: ^3
-  checksum: 227daea41f722caa017fc7d6f1f80d0e6c428491e57693e6bebc8312b85bcf3aace53cb3a925bda72fab59a6898fa127411d29348ec4b295e2263a7544cda611
+  checksum: 235ab1d200a711bfe2fffbf614f178db7dd053472cbac6f01d9342b98bb50ce69b6fa9c6ac71a6a9ed63bf855130e8592cd82b05021145de8cd793e32d97c742
   languageName: node
   linkType: hard
 
@@ -14612,7 +14644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:3.8.2":
+"winston@npm:3.8.2, winston@npm:^3.3.3":
   version: 3.8.2
   resolution: "winston@npm:3.8.2"
   dependencies:


### PR DESCRIPTION
* Aikaisemmin Sentryyn lähetettiin vain virheet mitä ei otettu kiinni. Lähetetään mieluummin kaikki virheet.
* Poistetaan `winston-daily-rotate-file`: ei ole tarvetta lokittaa levylle.  App Runner koostaa lokit konsolista ja kehittäessä käytetään konsolia.
* Kun kirjoitetaan lokia prod/staging-ympäristöissä, käytetään JSON-formaattia
* Sentryn init-funktioille piti erikseen passata asetus, että ei lokiteta virheitä konsoliin, kun ne lähetetään Sentryyn. `winston` hoitaa konsoliin tulevat lokit.