### PR TITLE
Update to MongoDB 6.0.6

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - mongo
 
   mongo:
-    image: mongo:5.0.14-focal
+    image: mongo:6.0.6-jammy
     restart: always
     ports:
       - 27017:27017

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docker:build-dev": "yarn build-front:dev && docker build . -t konsti-dev",
     "docker:start-dev-with-local-db": "yarn docker:build-dev && docker run -p 5000:5000 -d --env-file ./docker/docker-dev.env konsti-dev",
     "docker:db": "yarn docker:db-run 2>/dev/null || yarn docker:db-start",
-    "docker:db-run": "docker run -p 27017:27017 -d --name konsti-mongodb mongo:5.0.14-focal",
+    "docker:db-run": "docker run -p 27017:27017 -d --name konsti-mongodb mongo:6.0.6-jammy",
     "docker:db-start": "docker start konsti-mongodb",
     "eslint-rules": "eslint --print-config .eslintrc.js",
     "eslint-timings": "cross-env TIMING=1 yarn eslint",

--- a/server/src/test/setupTests.ts
+++ b/server/src/test/setupTests.ts
@@ -21,4 +21,4 @@ logger.error = throwOnErrorLog
     })
   : vi.fn().mockImplementation(() => {});
 
-process.env.MONGOMS_VERSION = "5.0.14";
+process.env.MONGOMS_VERSION = "6.0.6";


### PR DESCRIPTION
* Update to MongoDB 6.0.6
* Shared free MongoDB Atlas instance was updated to 6.0.6