### PR TITLE
Fix vitest timeout

### DIFF
--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./src/test/setupTests.ts"],
-    testTimeout: 60000,
     exclude: ["playwright"],
   },
   resolve: {

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   test: {
     environment: "node",
     setupFiles: ["./src/test/setupTests.ts"],
-    testTimeout: 60000,
+    testTimeout: 30000,
+    hookTimeout: 60000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Fix `vitest` timeout: enough time to download mongodb binary