### PR TITLE
Disallow react default import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,6 @@ module.exports = {
   rules: {
     // eslint
     "no-param-reassign": "error",
-    "no-restricted-imports": ["error", { patterns: ["../*"] }],
     "no-console": "error",
     "object-shorthand": "error",
     "array-callback-return": "off",
@@ -101,6 +100,24 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": [
       "error",
       { vars: "all", args: "all", argsIgnorePattern: "^_" },
+    ],
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "react",
+            importNames: ["default"],
+            message: "Please use named imports, e.g. { useEffect }",
+          },
+        ],
+        patterns: [
+          {
+            group: ["../*"],
+            message: "Relative import (../) not allowed, use absolute import",
+          },
+        ],
+      },
     ],
     "@typescript-eslint/strict-boolean-expressions": "off", // Forces unwanted code style
     "@typescript-eslint/restrict-template-expressions": "off", // Requires typing catch(e) every time

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -10,10 +10,10 @@ module.exports = {
 
   extends: [
     "plugin:eslint-plugin-react/recommended",
+    "plugin:eslint-plugin-react/jsx-runtime",
     "plugin:eslint-plugin-jsx-a11y/recommended",
     "plugin:testing-library/react",
     "plugin:react-hooks/recommended",
-    "plugin:react/jsx-runtime",
   ],
 
   env: {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,6 +1,7 @@
 import "core-js/stable";
 import "regenerator-runtime/runtime";
 import { createRoot } from "react-dom/client";
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import React, { Suspense, lazy } from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";


### PR DESCRIPTION
Disallow `react` default import since we don't need to import `React` on imports