### PR TITLE
Remove signup always open from PFS megagame

### DIFF
--- a/shared/config/sharedConfig.ts
+++ b/shared/config/sharedConfig.ts
@@ -149,7 +149,8 @@ export const sharedConfig: SharedConfig = {
 
   // These program items have their signup always open even if signup mode is set to algorithm
   directSignupAlwaysOpenIds: [
-    "p6673", // PFS multi-table special: Pathfinder Society #3-98: Expedition into Pallid Peril
+    "dummy_id", // Because tests require this, should be fixed
+    // "p6673", // PFS multi-table special: Pathfinder Society #3-98: Expedition into Pallid Peril
   ],
 
   // These program items are hand picked to be exported from Kompassi


### PR DESCRIPTION
Remove signup always open from PFS megagame