### PR TITLE
Don't remove signups from moved program items

### DIFF
--- a/server/src/features/player-assignment/padg/utils/runPadgAssignment.ts
+++ b/server/src/features/player-assignment/padg/utils/runPadgAssignment.ts
@@ -28,7 +28,7 @@ export const runPadgAssignment = (
     return groupsResult;
   }
   const groups = unwrapResult(groupsResult);
-  const events = getEvents(signedGames);
+  const events = getEvents(signedGames, signups);
   const listResult = getList(playerGroups, startTime, signups);
   if (isErrorResult(listResult)) {
     return listResult;

--- a/server/src/features/player-assignment/random/utils/getRandomAssignEvents.ts
+++ b/server/src/features/player-assignment/random/utils/getRandomAssignEvents.ts
@@ -1,14 +1,34 @@
+import dayjs from "dayjs";
 import { Game } from "shared/typings/models/game";
 import { RandomAssignEvent } from "server/typings/padgRandomAssign.typings";
+import { Signup } from "server/features/signup/signup.typings";
 
 export const getRandomAssignEvents = (
-  signedGames: readonly Game[]
+  signedGames: readonly Game[],
+  signups: readonly Signup[]
 ): RandomAssignEvent[] => {
   return signedGames.map((signedGame) => {
+    // Program item can have existing signups if program item's start time has changed
+    // Consider existing signups when determining program item attendee limits
+    const gameSignup = signups.find(
+      (signup) => signup.game.gameId === signedGame.gameId
+    );
+
+    const changedSignups = gameSignup?.userSignups.filter((userSignup) => {
+      const startTimeChanged = !dayjs(userSignup.time).isSame(
+        dayjs(signedGame.startTime)
+      );
+      if (startTimeChanged) {
+        return true;
+      }
+    });
+
+    const currentSignups = changedSignups?.length ?? 0;
+
     return {
       id: signedGame.gameId,
-      min: signedGame.minAttendance,
-      max: signedGame.maxAttendance,
+      min: signedGame.minAttendance - currentSignups,
+      max: signedGame.maxAttendance - currentSignups,
       groups: [],
     };
   });

--- a/server/src/features/player-assignment/random/utils/runRandomAssignment.ts
+++ b/server/src/features/player-assignment/random/utils/runRandomAssignment.ts
@@ -35,7 +35,7 @@ export const runRandomAssignment = (
     return groupsResult;
   }
   const groups = unwrapResult(groupsResult);
-  const events = getRandomAssignEvents(signedGames);
+  const events = getRandomAssignEvents(signedGames, signups);
   const listResult = getList(playerGroups, startTime, signups);
   if (isErrorResult(listResult)) {
     return listResult;

--- a/server/src/features/player-assignment/runAssignment.test.ts
+++ b/server/src/features/player-assignment/runAssignment.test.ts
@@ -466,7 +466,7 @@ describe("Assignment with multiple program types and directSignupAlwaysOpen", ()
       signedGames: [{ ...mockSignedGames[0] }],
     });
 
-    // User has previous signup from moved program item - this should be removed by assignment result
+    // User has previous signup from moved program item - this should be replaced by assignment result
     await saveSignup({
       ...mockPostEnteredGameRequest,
       enteredGameId: testGame2.gameId,

--- a/server/src/features/player-assignment/runAssignmentPadg.test.ts
+++ b/server/src/features/player-assignment/runAssignmentPadg.test.ts
@@ -130,7 +130,7 @@ test("Assignment with valid data should return success with padg strategy", asyn
   await assertUserUpdatedCorrectly(updatedUsers2);
 });
 
-test("Should adjust maximum attendee count if there are previous signups from moved program items", async () => {
+test("Should adjust attendee limits if there are previous signups from moved program items", async () => {
   const assignmentStrategy = AssignmentStrategy.PADG;
 
   await saveGames([{ ...testGame, minAttendance: 2, maxAttendance: 2 }]);

--- a/server/src/features/player-assignment/runAssignmentPadg.test.ts
+++ b/server/src/features/player-assignment/runAssignmentPadg.test.ts
@@ -17,6 +17,22 @@ import { AssignmentStrategy } from "shared/config/sharedConfig.types";
 import { sharedConfig } from "shared/config/sharedConfig";
 import { AssignmentResultStatus } from "server/typings/result.typings";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
+import { testGame } from "shared/tests/testGame";
+import { saveGames } from "server/features/game/gameRepository";
+import { saveUser } from "server/features/user/userRepository";
+import { saveSignedGames } from "server/features/user/signed-game/signedGameRepository";
+import {
+  mockPostEnteredGameRequest,
+  mockSignedGames,
+  mockUser,
+  mockUser2,
+  mockUser3,
+  mockUser4,
+} from "server/test/mock-data/mockUser";
+import {
+  findSignups,
+  saveSignup,
+} from "server/features/signup/signupRepository";
 
 let mongoServer: MongoMemoryServer;
 
@@ -112,6 +128,74 @@ test("Assignment with valid data should return success with padg strategy", asyn
 
   const updatedUsers2 = assignResults2.results.map((result) => result.username);
   await assertUserUpdatedCorrectly(updatedUsers2);
+});
+
+test("Should adjust maximum attendee count if there are previous signups from moved program items", async () => {
+  const assignmentStrategy = AssignmentStrategy.PADG;
+
+  await saveGames([{ ...testGame, minAttendance: 2, maxAttendance: 2 }]);
+  await saveUser(mockUser);
+  await saveUser(mockUser2);
+  await saveUser(mockUser3);
+  await saveUser(mockUser4);
+
+  // ** Save previous signups
+
+  // This should remain because of different startTime
+  await saveSignup({
+    ...mockPostEnteredGameRequest,
+    startTime: dayjs(testGame.startTime).subtract(1, "hours").toISOString(),
+  });
+
+  // This should be removed becase of same startTime
+  await saveSignup({
+    ...mockPostEnteredGameRequest,
+    username: mockUser2.username,
+  });
+
+  // ** Save selected games
+
+  // This will get assigned
+  await saveSignedGames({
+    username: mockUser3.username,
+    signedGames: [{ ...mockSignedGames[0], priority: 1 }],
+  });
+
+  // This will not get assigned because program item full
+  await saveSignedGames({
+    username: mockUser4.username,
+    signedGames: [{ ...mockSignedGames[0], priority: 3 }],
+  });
+
+  const assignResults = unsafelyUnwrapResult(
+    await runAssignment({
+      assignmentStrategy,
+      startTime: testGame.startTime,
+    })
+  );
+  expect(assignResults.status).toEqual("success");
+  expect(assignResults.results.length).toEqual(1);
+
+  const signupsAfterUpdate = unsafelyUnwrapResult(await findSignups());
+
+  const assignmentSignup = signupsAfterUpdate.find(
+    (signup) => signup.game.gameId === testGame.gameId
+  );
+
+  expect(assignmentSignup?.userSignups).toMatchObject([
+    {
+      username: mockUser.username,
+      time: dayjs(testGame.startTime).subtract(1, "hours").toISOString(),
+      message: "",
+      priority: 0,
+    },
+    {
+      username: mockUser3.username,
+      time: mockSignedGames[0].gameDetails.startTime,
+      message: "",
+      priority: 1,
+    },
+  ]);
 });
 
 test("Assignment with no games should return error with padg strategy", async () => {

--- a/server/src/features/player-assignment/runAssignmentRandom.test.ts
+++ b/server/src/features/player-assignment/runAssignmentRandom.test.ts
@@ -130,7 +130,7 @@ test("Assignment with valid data should return success with random strategy", as
   await assertUserUpdatedCorrectly(updatedUsers2);
 });
 
-test("Should adjust maximum attendee count if there are previous signups from moved program items", async () => {
+test("Should adjust attendee limits if there are previous signups from moved program items", async () => {
   const assignmentStrategy = AssignmentStrategy.RANDOM;
 
   await saveGames([{ ...testGame, minAttendance: 2, maxAttendance: 2 }]);

--- a/server/src/features/player-assignment/runAssignmentRandom.test.ts
+++ b/server/src/features/player-assignment/runAssignmentRandom.test.ts
@@ -17,6 +17,22 @@ import { AssignmentStrategy } from "shared/config/sharedConfig.types";
 import { sharedConfig } from "shared/config/sharedConfig";
 import { AssignmentResultStatus } from "server/typings/result.typings";
 import { unsafelyUnwrapResult } from "server/test/utils/unsafelyUnwrapResult";
+import { saveGames } from "server/features/game/gameRepository";
+import { testGame } from "shared/tests/testGame";
+import { saveUser } from "server/features/user/userRepository";
+import {
+  mockPostEnteredGameRequest,
+  mockSignedGames,
+  mockUser,
+  mockUser2,
+  mockUser3,
+  mockUser4,
+} from "server/test/mock-data/mockUser";
+import {
+  findSignups,
+  saveSignup,
+} from "server/features/signup/signupRepository";
+import { saveSignedGames } from "server/features/user/signed-game/signedGameRepository";
 
 let mongoServer: MongoMemoryServer;
 
@@ -112,6 +128,74 @@ test("Assignment with valid data should return success with random strategy", as
 
   const updatedUsers2 = assignResults2.results.map((result) => result.username);
   await assertUserUpdatedCorrectly(updatedUsers2);
+});
+
+test("Should adjust maximum attendee count if there are previous signups from moved program items", async () => {
+  const assignmentStrategy = AssignmentStrategy.RANDOM;
+
+  await saveGames([{ ...testGame, minAttendance: 2, maxAttendance: 2 }]);
+  await saveUser(mockUser);
+  await saveUser(mockUser2);
+  await saveUser(mockUser3);
+  await saveUser(mockUser4);
+
+  // ** Save previous signups
+
+  // This should remain because of different startTime
+  await saveSignup({
+    ...mockPostEnteredGameRequest,
+    startTime: dayjs(testGame.startTime).subtract(1, "hours").toISOString(),
+  });
+
+  // This should be removed becase of same startTime
+  await saveSignup({
+    ...mockPostEnteredGameRequest,
+    username: mockUser2.username,
+  });
+
+  // ** Save selected games
+
+  // This will get assigned
+  await saveSignedGames({
+    username: mockUser3.username,
+    signedGames: [{ ...mockSignedGames[0], priority: 1 }],
+  });
+
+  // This will not get assigned because program item full
+  await saveSignedGames({
+    username: mockUser4.username,
+    signedGames: [{ ...mockSignedGames[0], priority: 3 }],
+  });
+
+  const assignResults = unsafelyUnwrapResult(
+    await runAssignment({
+      assignmentStrategy,
+      startTime: testGame.startTime,
+    })
+  );
+  expect(assignResults.status).toEqual("success");
+  expect(assignResults.results.length).toEqual(1);
+
+  const signupsAfterUpdate = unsafelyUnwrapResult(await findSignups());
+
+  const assignmentSignup = signupsAfterUpdate.find(
+    (signup) => signup.game.gameId === testGame.gameId
+  );
+
+  expect(assignmentSignup?.userSignups).toMatchObject([
+    {
+      username: mockUser.username,
+      time: dayjs(testGame.startTime).subtract(1, "hours").toISOString(),
+      message: "",
+      priority: 0,
+    },
+    {
+      username: mockUser3.username,
+      time: mockSignedGames[0].gameDetails.startTime,
+      message: "",
+      priority: 1,
+    },
+  ]);
 });
 
 test("Assignment with no games should return error with random strategy", async () => {

--- a/server/src/features/player-assignment/utils/getEvents.ts
+++ b/server/src/features/player-assignment/utils/getEvents.ts
@@ -3,6 +3,7 @@ import { Game } from "shared/typings/models/game";
 import { Event } from "server/typings/padgRandomAssign.typings";
 import { Signup } from "server/features/signup/signup.typings";
 
+// TODO: Merge this with getRandomAssignEvents
 export const getEvents = (
   signedGames: readonly Game[],
   signups: readonly Signup[]

--- a/server/src/features/player-assignment/utils/getEvents.ts
+++ b/server/src/features/player-assignment/utils/getEvents.ts
@@ -1,12 +1,34 @@
+import dayjs from "dayjs";
 import { Game } from "shared/typings/models/game";
 import { Event } from "server/typings/padgRandomAssign.typings";
+import { Signup } from "server/features/signup/signup.typings";
 
-export const getEvents = (signedGames: readonly Game[]): Event[] => {
+export const getEvents = (
+  signedGames: readonly Game[],
+  signups: readonly Signup[]
+): Event[] => {
   return signedGames.map((signedGame) => {
+    // Program item can have existing signups if program item's start time has changed
+    // Consider existing signups when determining program item attendee limits
+    const gameSignup = signups.find(
+      (signup) => signup.game.gameId === signedGame.gameId
+    );
+
+    const changedSignups = gameSignup?.userSignups.filter((userSignup) => {
+      const startTimeChanged = !dayjs(userSignup.time).isSame(
+        dayjs(signedGame.startTime)
+      );
+      if (startTimeChanged) {
+        return true;
+      }
+    });
+
+    const currentSignups = changedSignups?.length ?? 0;
+
     return {
       id: signedGame.gameId,
-      min: signedGame.minAttendance,
-      max: signedGame.maxAttendance,
+      min: signedGame.minAttendance - currentSignups,
+      max: signedGame.maxAttendance - currentSignups,
       groups: [],
     };
   });


### PR DESCRIPTION
* Don't remove signups from moved program items
* Save all assignment signups at once using `saveSignups`
  * If for some buggy reson there are more signups than seats in program item, give error and limit attendee count