### PR TITLE
Explicitly use jsdom localStorage in tests.

### DIFF
--- a/client/src/test/setupTests.ts
+++ b/client/src/test/setupTests.ts
@@ -1,7 +1,31 @@
+import { JSDOM } from "jsdom";
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
+import { beforeEach } from "vitest";
 import { getIconLibrary } from "client/utils/icons";
 import { initializeDayjs } from "shared/utils/initializeDayjs";
+
+// Node 25+ has a built-in localStorage that shadows the jsdom one we want to use,
+// so explicitly use the jsdom one.
+const storageWindow = new JSDOM("", {
+  url: "https://example.com",
+}).window;
+
+Object.defineProperties(globalThis, {
+  localStorage: {
+    value: storageWindow.localStorage,
+    configurable: true,
+  },
+  sessionStorage: {
+    value: storageWindow.sessionStorage,
+    configurable: true,
+  },
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
 
 // Icons
 getIconLibrary();

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.61.0",
     "@types/eslint-plugin-jsx-a11y": "6.10.1",
+    "@types/jsdom": "28.0.3",
     "@typescript-eslint/utils": "8.61.1",
     "@vitest/coverage-istanbul": "4.1.9",
     "@vitest/eslint-plugin": "1.6.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,6 +2542,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jsdom@npm:28.0.3":
+  version: 28.0.3
+  resolution: "@types/jsdom@npm:28.0.3"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/tough-cookie": "npm:*"
+    parse5: "npm:^8.0.0"
+    undici-types: "npm:^7.21.0"
+  checksum: 10c0/08b1cd61ee3e9610676be3c68a782a94667b86a5f73b8a262095d05f84c9e864fc11b25ae53450cd519a0abd46c202906a735bd61aa176257a981964bc5b1166
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -2700,6 +2712,13 @@ __metadata:
   version: 8.1.3
   resolution: "@types/supports-color@npm:8.1.3"
   checksum: 10c0/03aa3616b403f3deaeb774df6d3a3969845b0c9f449814a83c2c53eb6818f5f9b571ba205330b0ebe8e46f41fd550f581a34b4310b13f0e0448694cfff37ddbf
+  languageName: node
+  linkType: hard
+
+"@types/tough-cookie@npm:*":
+  version: 4.0.5
+  resolution: "@types/tough-cookie@npm:4.0.5"
+  checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
   languageName: node
   linkType: hard
 
@@ -7501,6 +7520,7 @@ __metadata:
     "@eslint/js": "npm:10.0.1"
     "@playwright/test": "npm:1.61.0"
     "@types/eslint-plugin-jsx-a11y": "npm:6.10.1"
+    "@types/jsdom": "npm:28.0.3"
     "@typescript-eslint/utils": "npm:8.61.1"
     "@vitest/coverage-istanbul": "npm:4.1.9"
     "@vitest/eslint-plugin": "npm:1.6.20"
@@ -9461,7 +9481,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^8.0.1":
+"parse5@npm:^8.0.0, parse5@npm:^8.0.1":
   version: 8.0.1
   resolution: "parse5@npm:8.0.1"
   dependencies:
@@ -11625,6 +11645,13 @@ __metadata:
   version: 7.24.6
   resolution: "undici-types@npm:7.24.6"
   checksum: 10c0/d9cd8befb643ac904615c280a095ba4240531f6bb4a5e75a22a7483630ca8d3f1016d2ab6ace6ceda1f63b3a2db2fe037fafe121d6917a0187573aa548ff78ca
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:^7.21.0":
+  version: 7.28.0
+  resolution: "undici-types@npm:7.28.0"
+  checksum: 10c0/e1230791cfbaf7fc88a4ebb5282423886a2fb325572234437a3e9c9f7dff970bebe12d5672d6d23a3584119d6d43f8222d06531ed749d8ddeb3551f004fca55d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tests fail when Konsti is run on Node 25 or newer, fix by explicitly using jsdom localStorage in tests.