### PR TITLE
Move ingress to Traefik

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
           cache: "yarn"
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
           cache: "yarn"
@@ -131,7 +131,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
           cache: "yarn"
@@ -144,14 +144,14 @@ jobs:
       # job died before uploading) then only warns instead of failing the job,
       # and the merge script tolerates the missing input
       - name: Download vitest coverage
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-vitest
           merge-multiple: true
           path: coverage/vitest
 
       - name: Download shard coverage
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-e2e-*
           path: coverage/e2e-shards

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: qb-arc-runners
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - name: Cache skaffold
@@ -73,12 +73,12 @@ jobs:
         uses: actions/cache@v6
         with:
           path: bin/kubectl
-          key: ${{ runner.os }}-kubectl-v1.22.0
+          key: ${{ runner.os }}-kubectl-v1.36.2
       - name: Download kubectl
         if: steps.cache-kubectl.outputs.cache-hit != 'true'
         run: |
           mkdir -p bin
-          curl -Lo bin/kubectl https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl
+          curl -Lo bin/kubectl https://dl.k8s.io/release/v1.36.2/bin/linux/amd64/kubectl
           chmod +x bin/kubectl
       - name: Add skaffold and kubectl to PATH
         run: echo "$PWD/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           args: -color
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
           cache: "yarn"
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
           cache: "yarn"
@@ -129,7 +129,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
           cache: "yarn"
@@ -174,7 +174,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
           cache: "yarn"
@@ -222,7 +222,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Use Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
           cache: "yarn"
@@ -232,7 +232,7 @@ jobs:
           YARN_ENABLE_HARDENED_MODE=1 yarn --immutable
 
       - name: Download blob reports
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: all-blob-reports
           pattern: blob-report-*

--- a/kubernetes/default.vars.yaml
+++ b/kubernetes/default.vars.yaml
@@ -29,7 +29,7 @@ ingress_public_hostnames_https:
 ingress_letsencrypt_enabled: false
 ingress_letsencrypt_cluster_issuer: letsencrypt-prod
 
-ingress_class_name: nginx
+ingress_class_name: traefik
 
 mongodb_managed: true
 mongodb_image: mongo:8.0.26-noble
@@ -103,17 +103,17 @@ konsti_environment:
         name: konsti
         key: kompassiClientSecret
 
-# Default annotations work for nginx ingress with or without LetsEncrypt TLS. Override if you need something else.
+# The https-redirect and www-redirect middlewares must only be attached where TLS is
+# actually configured (not local/dev without letsencrypt) - see
+# infrastructure/kubernetes/traefik-middlewares.yaml for why https-redirect is a per-app
+# opt-in Middleware rather than a global entrypoint redirect (ACME HTTP-01 safety).
+# www-redirect replaces from-to-www-redirect: it 308-redirects www.<host> -> <host>
+# over HTTPS, matching this app's www.ropekonsti.fi -> ropekonsti.fi setup below.
 ingress_annotations: !If
   test: !Var ingress_letsencrypt_enabled
   then:
     cert-manager.io/cluster-issuer: !Var ingress_letsencrypt_cluster_issuer
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
-    kubernetes.io/ingress.class: "nginx"
-  else:
-    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
-    kubernetes.io/ingress.class: "nginx"
+    traefik.ingress.kubernetes.io/router.middlewares: default-https-redirect@kubernetescrd,default-www-redirect@kubernetescrd
 
 # Hostnames to include as SANs on the TLS certificate. Defaults to the public
 # hostnames; override to add non-routable names (e.g. a www alias that is only


### PR DESCRIPTION
NOTE: Let me handle merging – needs to be synced with ingress controller flip

We're moving from ingress-nginx to Traefik. This changes the ingress class and associated annotations to match.