### PR TITLE
Add www.ropekonsti.fi as a routed host so it actually redirects

### DIFF
--- a/kubernetes/default.vars.yaml
+++ b/kubernetes/default.vars.yaml
@@ -116,8 +116,10 @@ ingress_annotations: !If
     traefik.ingress.kubernetes.io/router.middlewares: default-https-redirect@kubernetescrd,default-www-redirect@kubernetescrd
 
 # Hostnames to include as SANs on the TLS certificate. Defaults to the public
-# hostnames; override to add non-routable names (e.g. a www alias that is only
-# 308-redirected via from-to-www-redirect and never gets its own ingress rule).
+# hostnames. Unlike ingress-nginx's from-to-www-redirect, Traefik has no
+# annotation that redirects a host without its own ingress rule, so a www
+# alias etc. needs an entry in ingress_public_hostnames (which also adds it
+# here) to actually get the www-redirect middleware applied to it.
 ingress_cert_hostnames: !Var ingress_public_hostnames
 
 ingress_tls: !If

--- a/kubernetes/production.vars.yaml
+++ b/kubernetes/production.vars.yaml
@@ -1,18 +1,12 @@
 ingress_public_hostnames:
   - ropekonsti.fi
+  - www.ropekonsti.fi
 
 ingress_public_hostnames_http:
   - http://ropekonsti.fi
 
 ingress_public_hostnames_https:
   - https://ropekonsti.fi
-
-# www is not a routable host: the from-to-www-redirect annotation 308-redirects
-# www.ropekonsti.fi -> ropekonsti.fi. It must still be a cert SAN so that redirect
-# is served over a valid certificate (HTTPS -> HTTPS requires both FQDNs on the cert)
-ingress_cert_hostnames:
-  - ropekonsti.fi
-  - www.ropekonsti.fi
 
 konsti_secret_managed: false
 konsti_frontend_env: prod


### PR DESCRIPTION
Traefik has no equivalent of ingress-nginx's from-to-www-redirect
annotation: without its own ingress rule, www.ropekonsti.fi had no
router at all and returned 404 instead of redirecting to the bare
domain. Adding it as a second entry in ingress_public_hostnames gives
it a route (same backend) so the existing www-redirect middleware can
actually catch and redirect it.
